### PR TITLE
typo in image name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ endif
 .PHONY: test-unit
 
 images:
-	imagebuilder -f Dockerfile -t openshift/cluster-openshift-apiserver-operator .
+	imagebuilder -f Dockerfile -t openshift/origin-cluster-openshift-apiserver-operator .
 .PHONY: images
 
 clean:


### PR DESCRIPTION
/assign @tnozicka 

The image is prefixed with origin and needs that prefix to work locally.