### PR TITLE
stop managing the network apis

### DIFF
--- a/pkg/operator/sync_openshiftapiserver_v311_00.go
+++ b/pkg/operator/sync_openshiftapiserver_v311_00.go
@@ -155,7 +155,6 @@ func manageAPIServices_v311_00_to_latest(client apiregistrationv1client.APIServi
 		{Group: "authorization.openshift.io", Version: "v1"},
 		{Group: "build.openshift.io", Version: "v1"},
 		{Group: "image.openshift.io", Version: "v1"},
-		{Group: "network.openshift.io", Version: "v1"},
 		{Group: "oauth.openshift.io", Version: "v1"},
 		{Group: "project.openshift.io", Version: "v1"},
 		{Group: "quota.openshift.io", Version: "v1"},


### PR DESCRIPTION
In 4.0, the networking group is CRD based. This stops active management for it.  Related to https://github.com/openshift/origin/pull/21184, but neither prereqs the other.

/assign @mfojtik 
fyi @squeed @openshift/sig-networking 