### PR TITLE
 don't manage apiservices until daemonset is up

### DIFF
--- a/bindata/v3.11.0/openshift-apiserver/ds.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/ds.yaml
@@ -41,6 +41,17 @@ spec:
           name: etcd-client
         - mountPath: /var/run/secrets/serving-cert
           name: serving-cert
+        livenessProbe:
+          initialDelaySeconds: 30
+          httpGet:
+            scheme: HTTPS
+            port: 8443
+            path: healthz
+        readinessProbe:
+          httpGet:
+            scheme: HTTPS
+            port: 8443
+            path: healthz
       volumes:
       - name: config
         configMap:

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -168,6 +168,17 @@ spec:
           name: etcd-client
         - mountPath: /var/run/secrets/serving-cert
           name: serving-cert
+        livenessProbe:
+          initialDelaySeconds: 30
+          httpGet:
+            scheme: HTTPS
+            port: 8443
+            path: healthz
+        readinessProbe:
+          httpGet:
+            scheme: HTTPS
+            port: 8443
+            path: healthz
       volumes:
       - name: config
         configMap:


### PR DESCRIPTION
This prevents the initial creation of apiservices that won't work.

/assign @mfojtik 