### PR TITLE
move to operator specific namespace

### DIFF
--- a/manifests/0000_20_cluster-openshift-apiserver-operator_00_namespace.yaml
+++ b/manifests/0000_20_cluster-openshift-apiserver-operator_00_namespace.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   labels:
     openshift.io/run-level: "0"
-  name: openshift-core-operators
+  name: openshift-cluster-openshift-apiserver-operator

--- a/manifests/0000_20_cluster-openshift-apiserver-operator_03_configmap.yaml
+++ b/manifests/0000_20_cluster-openshift-apiserver-operator_03_configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: openshift-core-operators
+  namespace: openshift-cluster-openshift-apiserver-operator
   name: openshift-cluster-openshift-apiserver-operator-config
 data:
   config.yaml: |

--- a/manifests/0000_20_cluster-openshift-apiserver-operator_04_roles.yaml
+++ b/manifests/0000_20_cluster-openshift-apiserver-operator_04_roles.yaml
@@ -7,5 +7,5 @@ roleRef:
   name: cluster-admin
 subjects:
 - kind: ServiceAccount
-  namespace: openshift-core-operators
+  namespace: openshift-cluster-openshift-apiserver-operator
   name: openshift-cluster-openshift-apiserver-operator

--- a/manifests/0000_20_cluster-openshift-apiserver-operator_05_serviceaccount.yaml
+++ b/manifests/0000_20_cluster-openshift-apiserver-operator_05_serviceaccount.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: openshift-core-operators
+  namespace: openshift-cluster-openshift-apiserver-operator
   name: openshift-cluster-openshift-apiserver-operator
   labels:
     app: openshift-cluster-openshift-apiserver-operator

--- a/manifests/0000_20_cluster-openshift-apiserver-operator_06_service.yaml
+++ b/manifests/0000_20_cluster-openshift-apiserver-operator_06_service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: openshift-core-operators
+  namespace: openshift-cluster-openshift-apiserver-operator
   name: openshift-apiserver-operator
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: cluster-apiserver-operator-serving-cert

--- a/manifests/0000_20_cluster-openshift-apiserver-operator_07_deployment.yaml
+++ b/manifests/0000_20_cluster-openshift-apiserver-operator_07_deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: openshift-core-operators
+  namespace: openshift-cluster-openshift-apiserver-operator
   name: openshift-cluster-openshift-apiserver-operator
   labels:
     app: openshift-cluster-openshift-apiserver-operator

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -79,8 +79,8 @@ func RunOperator(clientConfig *rest.Config, stopCh <-chan struct{}) error {
 	)
 
 	clusterOperatorStatus := status.NewClusterOperatorStatusController(
-		"openshift-apiserver",
-		"openshift-apiserver",
+		"openshift-cluster-openshift-apiserver-operator",
+		"openshift-cluster-openshift-apiserver-operator",
 		dynamicClient,
 		&operatorStatusProvider{informers: operatorConfigInformers},
 	)


### PR DESCRIPTION
Moves our namespace to openshift-cluster-openshift-apiserver-operator and updates our ClusterOperator to match.

/assign @sanchezl