### PR TITLE
Configure routing subdomain

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -30,6 +30,8 @@ import (
 )
 
 const (
+	clusterConfigNamespaceName = "kube-system"
+	clusterConfigName          = "cluster-config-v1"
 	etcdNamespaceName          = "kube-system"
 	kubeAPIServerNamespaceName = "openshift-kube-apiserver"
 	targetNamespaceName        = "openshift-apiserver"
@@ -52,6 +54,7 @@ func NewKubeApiserverOperator(
 	operatorConfigInformer operatorconfiginformerv1alpha1.OpenShiftAPIServerOperatorConfigInformer,
 	kubeInformersForOpenShiftAPIServerNamespace kubeinformers.SharedInformerFactory,
 	kubeInformersForEtcdNamespace kubeinformers.SharedInformerFactory,
+	kubeInformersForClusterConfigNamespace kubeinformers.SharedInformerFactory,
 	kubeInformersForKubeAPIServerNamespace kubeinformers.SharedInformerFactory,
 	apiregistrationInformers apiregistrationinformers.SharedInformerFactory,
 	operatorConfigClient operatorconfigclientv1alpha1.OpenshiftapiserverV1alpha1Interface,
@@ -71,6 +74,7 @@ func NewKubeApiserverOperator(
 	operatorConfigInformer.Informer().AddEventHandler(c.eventHandler())
 	kubeInformersForEtcdNamespace.Core().V1().ConfigMaps().Informer().AddEventHandler(c.eventHandler())
 	kubeInformersForEtcdNamespace.Core().V1().Secrets().Informer().AddEventHandler(c.eventHandler())
+	kubeInformersForClusterConfigNamespace.Core().V1().ConfigMaps().Informer().AddEventHandler(c.eventHandler())
 	kubeInformersForKubeAPIServerNamespace.Core().V1().ConfigMaps().Informer().AddEventHandler(c.eventHandler())
 	kubeInformersForOpenShiftAPIServerNamespace.Core().V1().ConfigMaps().Informer().AddEventHandler(c.eventHandler())
 	kubeInformersForOpenShiftAPIServerNamespace.Core().V1().ServiceAccounts().Informer().AddEventHandler(c.eventHandler())

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -57,6 +57,7 @@ func RunOperator(clientConfig *rest.Config, stopCh <-chan struct{}) error {
 	kubeInformersForOpenShiftAPIServerNamespace := kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, 10*time.Minute, kubeinformers.WithNamespace(targetNamespaceName))
 	kubeInformersForKubeAPIServerNamespace := kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, 10*time.Minute, kubeinformers.WithNamespace(kubeAPIServerNamespaceName))
 	kubeInformersForEtcdNamespace := kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, 10*time.Minute, kubeinformers.WithNamespace(etcdNamespaceName))
+	kubeInformersForClusterConfigNamespace := kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, 10*time.Minute, kubeinformers.WithNamespace(clusterConfigNamespaceName))
 	apiregistrationInformers := apiregistrationinformers.NewSharedInformerFactory(apiregistrationv1Client, 10*time.Minute)
 	imageConfigInformers := imageconfiginformers.NewSharedInformerFactory(configClient, 10*time.Minute)
 
@@ -64,6 +65,7 @@ func RunOperator(clientConfig *rest.Config, stopCh <-chan struct{}) error {
 		operatorConfigInformers.Openshiftapiserver().V1alpha1().OpenShiftAPIServerOperatorConfigs(),
 		kubeInformersForOpenShiftAPIServerNamespace,
 		kubeInformersForEtcdNamespace,
+		kubeInformersForClusterConfigNamespace,
 		kubeInformersForKubeAPIServerNamespace,
 		apiregistrationInformers,
 		operatorConfigClient.OpenshiftapiserverV1alpha1(),
@@ -74,6 +76,7 @@ func RunOperator(clientConfig *rest.Config, stopCh <-chan struct{}) error {
 	configObserver := NewConfigObserver(
 		operatorConfigInformers.Openshiftapiserver().V1alpha1().OpenShiftAPIServerOperatorConfigs(),
 		kubeInformersForEtcdNamespace,
+		kubeInformersForClusterConfigNamespace,
 		imageConfigInformers,
 		operatorConfigClient.OpenshiftapiserverV1alpha1(),
 	)
@@ -89,6 +92,7 @@ func RunOperator(clientConfig *rest.Config, stopCh <-chan struct{}) error {
 	kubeInformersForOpenShiftAPIServerNamespace.Start(stopCh)
 	kubeInformersForKubeAPIServerNamespace.Start(stopCh)
 	kubeInformersForEtcdNamespace.Start(stopCh)
+	kubeInformersForClusterConfigNamespace.Start(stopCh)
 	apiregistrationInformers.Start(stopCh)
 	imageConfigInformers.Start(stopCh)
 


### PR DESCRIPTION
* `pkg/operator/observe_config.go` (`Listers`): Add new lister `clusterConfigLister`.
(`ConfigObserver`): Add `clusterConfigSynced`.
(`NewConfigObserver`): Add `kubeInformersForClusterConfigNamespace` parameter, add `clusterConfigLister` to listers, and add `observeRoutingSubdomain` to observers.
(`observeRoutingSubdomain`): Add new observer to set `routingConfig.Subdomain` from the install config in the cluster config.
* `pkg/operator/operator.go`: Add constants `clusterConfigNamespaceName` and `clusterConfigName`.
(`NewKubeApiserverOperator`): Add `kubeInformersForClusterConfigNamespace` parameter and register the informer.
* `pkg/operator/starter.go` (`RunOperator`): Add new informer `kubeInformersForClusterConfigNamespace` and pass it to `NewKubeApiserverOperator` and `NewConfigObserver`.


This PR resolves [NE-100](https://jira.coreos.com/browse/NE-100).

---

I believe this is the correct place to perform the configuration.  The PR is WIP because I am not sure it is appropriate to get the configuration from the install config.  Perhaps better would be to read the ingress domain from a ClusterIngress resource, but that would require generating listers in cluster-ingress-operator and then importing them into cluster-openshift-apiserver-operator.

@ironcladlou

---

Before:
```
% oc get openshiftapiserveroperatorconfigs/instance -o 'jsonpath={.spec.observedConfig.routingConfig}'
% oc new-project hello-openshift
Now using project "hello-openshift" on server "https://mmasters-api.devcluster.openshift.com:6443".

You can add applications to this project with the 'new-app' command. For example, try:

    oc new-app centos/ruby-25-centos7~https://github.com/sclorg/ruby-ex.git

to build a new example application in Ruby.
% oc -n hello-openshift create -f ~/src/github.com/openshift/origin/examples/hello-openshift/hello-pod.json
pod/hello-openshift created
% oc -n hello-openshift expose pod/hello-openshift
service/hello-openshift exposed
% oc -n hello-openshift expose svc/hello-openshift
route.route.openshift.io/hello-openshift exposed
% oc -n hello-openshift get routes
NAME              HOST/PORT                                                          PATH      SERVICES          PORT      TERMINATION   WILDCARD
hello-openshift   hello-openshift-hello-openshift.router.default.svc.cluster.local             hello-openshift   8080                    None
% oc -n hello-openshift delete routes/hello-openshift
route.route.openshift.io "hello-openshift" deleted
% 
```
After:
```
% oc get openshiftapiserveroperatorconfigs/instance -o 'jsonpath={.spec.observedConfig.routingConfig}'
map[subdomain:mmasters.devcluster.openshift.com]
% oc -n hello-openshift expose svc/hello-openshift                                                                                                                                     [986/986]
route.route.openshift.io/hello-openshift exposed
% oc -n hello-openshift get routes
NAME              HOST/PORT                                                           PATH      SERVICES          PORT      TERMINATION   WILDCARD
hello-openshift   hello-openshift-hello-openshift.mmasters.devcluster.openshift.com             hello-openshift   8080                    None
% 
```