### PR TITLE
Update namespace in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@ The openshift-apiserver operator installs and maintains the openshift-apiserver 
 3. `make images`
 4. `docker tag openshift/origin-cluster-openshift-apiserver-operator:latest <yourdockerhubid>/origin-cluster-openshift-apiserver-operator:latest`
 5. `docker push <yourdockerhubid>/origin-cluster-openshift-apiserver-operator:latest`
-6. `oc edit -n openshift-core-operators deployment.apps/openshift-cluster-openshift-apiserver-operator` update the image to `<yourdockerhubid>/origin-cluster-openshift-apiserver-operator:latest` and update the pull policy to `Always`
-7. `oc delete pod -n openshift-core-operators --all` will cause the pod to be recreated and the image to be pulled.
+6. `oc edit -n openshift-cluster-openshift-apiserver-operator deployment.apps/openshift-cluster-openshift-apiserver-operator` update the image to `<yourdockerhubid>/origin-cluster-openshift-apiserver-operator:latest` and update the pull policy to `Always`
+7. `oc delete pod -n openshift-cluster-openshift-apiserver-operator --all` will cause the pod to be recreated and the image to be pulled.


### PR DESCRIPTION
https://github.com/openshift/cluster-openshift-apiserver-operator/pull/49 changed the operator's namespace from "openshift-core-operators" to "openshift-cluster-openshift-apiserver-operator" but did not update the README.