### PR TITLE
Use openshift-apiserver container name for easier debugging

### DIFF
--- a/bindata/v3.11.0/openshift-apiserver/ds.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/ds.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       serviceAccountName: openshift-apiserver-sa
       containers:
-      - name: apiserver
+      - name: openshift-apiserver
         image: ${IMAGE}
         imagePullPolicy: IfNotPresent
         command: ["hypershift", "openshift-apiserver"]

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -149,7 +149,7 @@ spec:
     spec:
       serviceAccountName: openshift-apiserver-sa
       containers:
-      - name: apiserver
+      - name: openshift-apiserver
         image: ${IMAGE}
         imagePullPolicy: IfNotPresent
         command: ["hypershift", "openshift-apiserver"]


### PR DESCRIPTION
"crictl ps -a" does not show pod names. So during disaster recovery full names for the containers is helpful.