### PR TITLE
Configure routing subdomain

### DIFF
--- a/pkg/operator/configobservation/ingresses/observe_ingresses.go
+++ b/pkg/operator/configobservation/ingresses/observe_ingresses.go
@@ -1,0 +1,55 @@
+package ingresses
+
+import (
+	"github.com/golang/glog"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/openshift/cluster-openshift-apiserver-operator/pkg/operator/configobservation"
+	"github.com/openshift/library-go/pkg/operator/configobserver"
+	"github.com/openshift/library-go/pkg/operator/events"
+)
+
+func ObserveIngressDomain(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (map[string]interface{}, []error) {
+	listers := genericListers.(configobservation.Listers)
+	var errs []error
+	prevObservedConfig := map[string]interface{}{}
+
+	routingConfigSubdomainPath := []string{"routingConfig", "subdomain"}
+	currentRoutingDomain, _, err := unstructured.NestedString(existingConfig, routingConfigSubdomainPath...)
+	if err != nil {
+		return prevObservedConfig, append(errs, err)
+	}
+	if len(currentRoutingDomain) > 0 {
+		err := unstructured.SetNestedField(prevObservedConfig, currentRoutingDomain, routingConfigSubdomainPath...)
+		if err != nil {
+			return prevObservedConfig, append(errs, err)
+		}
+	}
+
+	if !listers.IngressConfigSynced() {
+		glog.Warning("ingresses.config.openshift.io not synced")
+		return prevObservedConfig, errs
+	}
+
+	observedConfig := map[string]interface{}{}
+	configIngress, err := listers.IngressConfigLister.Get("cluster")
+	if errors.IsNotFound(err) {
+		glog.Warningf("ingress.config.openshift.io/default: not found")
+		return observedConfig, errs
+	}
+	if err != nil {
+		return prevObservedConfig, append(errs, err)
+	}
+
+	routingDomain := configIngress.Spec.Domain
+	if len(routingDomain) > 0 {
+		err = unstructured.SetNestedField(observedConfig, routingDomain, routingConfigSubdomainPath...)
+		if err != nil {
+			return prevObservedConfig, append(errs, err)
+		}
+	}
+
+	return observedConfig, errs
+}

--- a/pkg/operator/configobservation/interfaces.go
+++ b/pkg/operator/configobservation/interfaces.go
@@ -8,10 +8,12 @@ import (
 )
 
 type Listers struct {
-	ImageConfigLister  configlistersv1.ImageLister
-	EndpointsLister    corelistersv1.EndpointsLister
-	ImageConfigSynced  cache.InformerSynced
-	PreRunCachesSynced []cache.InformerSynced
+	ImageConfigLister   configlistersv1.ImageLister
+	IngressConfigLister configlistersv1.IngressLister
+	EndpointsLister     corelistersv1.EndpointsLister
+	ImageConfigSynced   cache.InformerSynced
+	IngressConfigSynced cache.InformerSynced
+	PreRunCachesSynced  []cache.InformerSynced
 }
 
 func (l Listers) PreRunHasSynced() []cache.InformerSynced {

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -15,7 +15,7 @@ import (
 	apiregistrationinformers "k8s.io/kube-aggregator/pkg/client/informers/externalversions"
 
 	configv1client "github.com/openshift/client-go/config/clientset/versioned"
-	imageconfiginformers "github.com/openshift/client-go/config/informers/externalversions"
+	configinformers "github.com/openshift/client-go/config/informers/externalversions"
 	"github.com/openshift/cluster-openshift-apiserver-operator/pkg/apis/openshiftapiserver/v1alpha1"
 	operatorconfigclient "github.com/openshift/cluster-openshift-apiserver-operator/pkg/generated/clientset/versioned"
 	operatorclientinformers "github.com/openshift/cluster-openshift-apiserver-operator/pkg/generated/informers/externalversions"
@@ -59,7 +59,7 @@ func RunOperator(controllerContext *controllercmd.ControllerContext) error {
 	kubeInformersForKubeAPIServerNamespace := kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, 10*time.Minute, kubeinformers.WithNamespace(kubeAPIServerNamespaceName))
 	kubeInformersForEtcdNamespace := kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, 10*time.Minute, kubeinformers.WithNamespace(etcdNamespaceName))
 	apiregistrationInformers := apiregistrationinformers.NewSharedInformerFactory(apiregistrationv1Client, 10*time.Minute)
-	imageConfigInformers := imageconfiginformers.NewSharedInformerFactory(configClient, 10*time.Minute)
+	configInformers := configinformers.NewSharedInformerFactory(configClient, 10*time.Minute)
 
 	operatorClient := &operatorClient{
 		informers: operatorConfigInformers,
@@ -83,7 +83,7 @@ func RunOperator(controllerContext *controllercmd.ControllerContext) error {
 		operatorClient,
 		operatorConfigInformers,
 		kubeInformersForEtcdNamespace,
-		imageConfigInformers,
+		configInformers,
 		controllerContext.EventRecorder,
 	)
 
@@ -99,7 +99,7 @@ func RunOperator(controllerContext *controllercmd.ControllerContext) error {
 	kubeInformersForKubeAPIServerNamespace.Start(controllerContext.StopCh)
 	kubeInformersForEtcdNamespace.Start(controllerContext.StopCh)
 	apiregistrationInformers.Start(controllerContext.StopCh)
-	imageConfigInformers.Start(controllerContext.StopCh)
+	configInformers.Start(controllerContext.StopCh)
 
 	go workloadController.Run(1, controllerContext.StopCh)
 	go configObserver.Run(1, controllerContext.StopCh)


### PR DESCRIPTION
* `pkg/operator/configobservation/configobservercontroller/observe_config_controller.go` (`NewConfigObserver`): Rename `imageConfigInformers` to `configInformers`, and use the same informer for both image configs and ingress configs.
Add `IngressConfigLister` and `IngressConfigSynced` to listers.
Add `ObserveIngressDomain` to observers.
Register event handler for ingresses.config.openshift.io.
* `pkg/operator/configobservation/ingresses/observe_ingresses.go` (`ObserveIngressDomain`): Add new observer to set `routingConfig.Subdomain` from the cluster ingress config.
* `pkg/operator/configobservation/interfaces.go` (`Listers`): Add `IngressConfigLister` and `IngressConfigSynced`.
* `pkg/operator/starter.go` (`RunOperator`): Rename `imageConfigInformers` to `configInformers`.

Related to [NE-100](https://jira.coreos.com/browse/NE-100).

Supersedes https://github.com/openshift/cluster-openshift-apiserver-operator/pull/51.

@ironcladlou, @deads2k

Before:
```
% oc get openshiftapiserveroperatorconfigs/instance -o $'jsonpath={.spec.observedConfig.routingConfig.subdomain}\n'

% oc new-project hello-openshift
Now using project "hello-openshift" on server "https://mmasters-api.devcluster.openshift.com:6443".

You can add applications to this project with the 'new-app' command. For example, try:

    oc new-app centos/ruby-25-centos7~https://github.com/sclorg/ruby-ex.git

to build a new example application in Ruby.
% oc -n hello-openshift create -f ~/src/github.com/openshift/origin/examples/hello-openshift/hello-pod.json
pod/hello-openshift created
% oc -n hello-openshift expose pod/hello-openshift
service/hello-openshift exposed
% oc -n hello-openshift expose svc/hello-openshift
route.route.openshift.io/hello-openshift exposed
% oc -n hello-openshift get routes
NAME              HOST/PORT                                                          PATH      SERVICES          PORT      TERMINATION   WILDCARD
hello-openshift   hello-openshift-hello-openshift.router.default.svc.cluster.local             hello-openshift   8080                    None
% oc -n hello-openshift delete routes/hello-openshift
route.route.openshift.io "hello-openshift" deleted
```
After:
```
% oc get openshiftapiserveroperatorconfigs/instance -o $'jsonpath={.spec.observedConfig.routingConfig.subdomain}\n'
apps.mmasters.devcluster.openshift.com
% oc -n hello-openshift expose svc/hello-openshift
route.route.openshift.io/hello-openshift exposed
% oc -n hello-openshift get routes
NAME              HOST/PORT                                                                PATH      SERVICES          PORT      TERMINATION   WILDCARD
hello-openshift   hello-openshift-hello-openshift.apps.mmasters.devcluster.openshift.com             hello-openshift   8080                    None
```