### PR TITLE
Fix handling of empty lists of registries

### DIFF
--- a/pkg/operator/configobservation/images/observe_images.go
+++ b/pkg/operator/configobservation/images/observe_images.go
@@ -72,9 +72,11 @@ func ObserveExternalRegistryHostnames(genericListers configobserver.Listers, exi
 	if err != nil {
 		return prevObservedConfig, append(errs, err)
 	}
-	err = unstructured.SetNestedSlice(prevObservedConfig, o, externalRegistryHostnamePath...)
-	if err != nil {
-		return prevObservedConfig, append(errs, err)
+	if len(o) > 0 {
+		err = unstructured.SetNestedSlice(prevObservedConfig, o, externalRegistryHostnamePath...)
+		if err != nil {
+			return prevObservedConfig, append(errs, err)
+		}
 	}
 
 	if !listers.ImageConfigSynced() {
@@ -98,13 +100,15 @@ func ObserveExternalRegistryHostnames(genericListers configobserver.Listers, exi
 	externalRegistryHostnames := configImage.Spec.ExternalRegistryHostnames
 	externalRegistryHostnames = append(externalRegistryHostnames, configImage.Status.ExternalRegistryHostnames...)
 
-	hostnames, err := Convert(externalRegistryHostnames)
-	if err != nil {
-		return prevObservedConfig, append(errs, err)
-	}
-	err = unstructured.SetNestedField(observedConfig, hostnames, externalRegistryHostnamePath...)
-	if err != nil {
-		return prevObservedConfig, append(errs, err)
+	if len(externalRegistryHostnames) > 0 {
+		hostnames, err := Convert(externalRegistryHostnames)
+		if err != nil {
+			return prevObservedConfig, append(errs, err)
+		}
+		err = unstructured.SetNestedField(observedConfig, hostnames, externalRegistryHostnamePath...)
+		if err != nil {
+			return prevObservedConfig, append(errs, err)
+		}
 	}
 
 	return observedConfig, errs
@@ -122,9 +126,11 @@ func ObserveAllowedRegistriesForImport(genericListers configobserver.Listers, ex
 	if err != nil {
 		return prevObservedConfig, append(errs, err)
 	}
-	err = unstructured.SetNestedSlice(prevObservedConfig, o, allowedRegistriesForImportPath...)
-	if err != nil {
-		return prevObservedConfig, append(errs, err)
+	if len(o) > 0 {
+		err = unstructured.SetNestedSlice(prevObservedConfig, o, allowedRegistriesForImportPath...)
+		if err != nil {
+			return prevObservedConfig, append(errs, err)
+		}
 	}
 
 	if !listers.ImageConfigSynced() {
@@ -143,13 +149,15 @@ func ObserveAllowedRegistriesForImport(genericListers configobserver.Listers, ex
 		return prevObservedConfig, append(errs, err)
 	}
 
-	allowed, err := Convert(configImage.Spec.AllowedRegistriesForImport)
-	if err != nil {
-		return prevObservedConfig, append(errs, err)
-	}
-	err = unstructured.SetNestedField(observedConfig, allowed, allowedRegistriesForImportPath...)
-	if err != nil {
-		return prevObservedConfig, append(errs, err)
+	if len(configImage.Spec.AllowedRegistriesForImport) > 0 {
+		allowed, err := Convert(configImage.Spec.AllowedRegistriesForImport)
+		if err != nil {
+			return prevObservedConfig, append(errs, err)
+		}
+		err = unstructured.SetNestedField(observedConfig, allowed, allowedRegistriesForImportPath...)
+		if err != nil {
+			return prevObservedConfig, append(errs, err)
+		}
 	}
 
 	return observedConfig, errs

--- a/pkg/operator/configobservation/images/observe_images_test.go
+++ b/pkg/operator/configobservation/images/observe_images_test.go
@@ -107,7 +107,7 @@ func TestObserveImageConfig(t *testing.T) {
 					AllowedRegistriesForImport: []configv1.RegistryLocation{},
 				},
 			},
-			expectedAllowedRegistries: []configv1.RegistryLocation{},
+			expectedAllowedRegistries: nil,
 		},
 	}
 


### PR DESCRIPTION
* `pkg/operator/configobservation/images/observe_images.go` (`ObserveExternalRegistryHostnames`, `ObserveAllowedRegistriesForImport`): Ignore empty `externalRegistryHostnames` or `allowedRegistriesForImport` values in old observed config, and omit them from new observed config.
* `pkg/operator/configobservation/images/observe_images_test.go`: Expect to get null for empty `allowedRegistriesForImport`.

These changes follow up #54 to avoid spuriously adding and removing `imagePolicyConfig` with null values, as observed in the operator's log output:
```
I1128 06:10:44.254039       1 config_observer_controller.go:115] writing updated observedConfig: {

A: }

B: "imagePolicyConfig":{"allowedRegistriesForImport":null,"externalRegistryHostnames":null}}

I1128 06:10:44.264287       1 config_observer_controller.go:115] writing updated observedConfig: {

A: "imagePolicyConfig":{"allowedRegistriesForImport":null,"externalRegistryHostnames":null}}

B: }
```
The same spurious adding and removing repeats while the operator runs.  I also observed the following in the openshiftapiserveroperatorconfig: 
```
status:
  conditions:
  - lastTransitionTime: null
    message: |-
      .imagePolicyConfig.allowedRegistriesForImport accessor error: <nil> is of the type <nil>, expected []interface{}
      .imagePolicyConfig.externalRegistryHostnames accessor error: <nil> is of the type <nil>, expected []interface{}
    reason: ConfigObservationError
    status: "True"
    type: ConfigObservationFailing
```

@bparees, please take a look.  I may be missing some subtlety in how null values and empty lists are handled in the API, JSON, or gRPC, but I figure the log output and status indicate that _something_ is amiss in the current logic.