### PR TITLE
Revert "add additional imageconfig api field handling"

### DIFF
--- a/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
+++ b/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
@@ -38,8 +38,6 @@ func NewConfigObserver(
 				},
 			},
 			images.ObserveInternalRegistryHostname,
-			images.ObserveExternalRegistryHostnames,
-			images.ObserveAllowedRegistriesForImport,
 		),
 	}
 	operatorConfigInformers.Openshiftapiserver().V1alpha1().OpenShiftAPIServerOperatorConfigs().Informer().AddEventHandler(c.EventHandler())

--- a/pkg/operator/configobservation/images/OWNERS
+++ b/pkg/operator/configobservation/images/OWNERS
@@ -1,5 +1,0 @@
-reviewers:
-  - bparees
-  - adambkaplan
-approvers:
-  - bparees

--- a/pkg/operator/configobservation/images/observe_images.go
+++ b/pkg/operator/configobservation/images/observe_images.go
@@ -1,17 +1,13 @@
 package images
 
 import (
-	"bytes"
-	"encoding/json"
-
 	"github.com/golang/glog"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	"github.com/openshift/library-go/pkg/operator/configobserver"
-
 	"github.com/openshift/cluster-openshift-apiserver-operator/pkg/operator/configobservation"
+	"github.com/openshift/library-go/pkg/operator/configobserver"
 )
 
 func ObserveInternalRegistryHostname(genericListers configobserver.Listers, existingConfig map[string]interface{}) (map[string]interface{}, []error) {
@@ -19,18 +15,9 @@ func ObserveInternalRegistryHostname(genericListers configobserver.Listers, exis
 	var errs []error
 	prevObservedConfig := map[string]interface{}{}
 
-	// first observe all the existing config values so that if we get any errors
-	// we can at least return those.
 	internalRegistryHostnamePath := []string{"imagePolicyConfig", "internalRegistryHostname"}
-	currentInternalRegistryHostname, _, err := unstructured.NestedString(existingConfig, internalRegistryHostnamePath...)
-	if err != nil {
-		return prevObservedConfig, append(errs, err)
-	}
-	if len(currentInternalRegistryHostname) > 0 {
-		err := unstructured.SetNestedField(prevObservedConfig, currentInternalRegistryHostname, internalRegistryHostnamePath...)
-		if err != nil {
-			return prevObservedConfig, append(errs, err)
-		}
+	if currentInternalRegistryHostname, _, _ := unstructured.NestedString(existingConfig, internalRegistryHostnamePath...); len(currentInternalRegistryHostname) > 0 {
+		unstructured.SetNestedField(prevObservedConfig, currentInternalRegistryHostname, internalRegistryHostnamePath...)
 	}
 
 	if !listers.ImageConfigSynced() {
@@ -38,7 +25,6 @@ func ObserveInternalRegistryHostname(genericListers configobserver.Listers, exis
 		return prevObservedConfig, errs
 	}
 
-	// now gather the cluster config and turn it into the observed config
 	observedConfig := map[string]interface{}{}
 	configImage, err := listers.ImageConfigLister.Get("cluster")
 	if errors.IsNotFound(err) {
@@ -46,128 +32,11 @@ func ObserveInternalRegistryHostname(genericListers configobserver.Listers, exis
 		return observedConfig, errs
 	}
 	if err != nil {
-		return prevObservedConfig, append(errs, err)
+		return prevObservedConfig, errs
 	}
-
 	internalRegistryHostName := configImage.Status.InternalRegistryHostname
 	if len(internalRegistryHostName) > 0 {
-		err = unstructured.SetNestedField(observedConfig, internalRegistryHostName, internalRegistryHostnamePath...)
-		if err != nil {
-			return prevObservedConfig, append(errs, err)
-		}
+		unstructured.SetNestedField(observedConfig, internalRegistryHostName, internalRegistryHostnamePath...)
 	}
-
 	return observedConfig, errs
-}
-
-func ObserveExternalRegistryHostnames(genericListers configobserver.Listers, existingConfig map[string]interface{}) (map[string]interface{}, []error) {
-	listers := genericListers.(configobservation.Listers)
-	var errs []error
-	prevObservedConfig := map[string]interface{}{}
-
-	// first observe all the existing config values so that if we get any errors
-	// we can at least return those.
-	externalRegistryHostnamePath := []string{"imagePolicyConfig", "externalRegistryHostnames"}
-	o, _, err := unstructured.NestedSlice(existingConfig, externalRegistryHostnamePath...)
-	if err != nil {
-		return prevObservedConfig, append(errs, err)
-	}
-	err = unstructured.SetNestedSlice(prevObservedConfig, o, externalRegistryHostnamePath...)
-	if err != nil {
-		return prevObservedConfig, append(errs, err)
-	}
-
-	if !listers.ImageConfigSynced() {
-		glog.Warning("images.config.openshift.io not synced")
-		return prevObservedConfig, errs
-	}
-
-	// now gather the cluster config and turn it into the observed config
-	observedConfig := map[string]interface{}{}
-	configImage, err := listers.ImageConfigLister.Get("cluster")
-	if errors.IsNotFound(err) {
-		glog.Warningf("image.config.openshift.io/cluster: not found")
-		return observedConfig, errs
-	}
-	if err != nil {
-		return prevObservedConfig, append(errs, err)
-	}
-
-	// User provided values take precedence, first entry in the array
-	// has special significance.
-	externalRegistryHostnames := configImage.Spec.ExternalRegistryHostnames
-	externalRegistryHostnames = append(externalRegistryHostnames, configImage.Status.ExternalRegistryHostnames...)
-
-	hostnames, err := Convert(externalRegistryHostnames)
-	if err != nil {
-		return prevObservedConfig, append(errs, err)
-	}
-	err = unstructured.SetNestedField(observedConfig, hostnames, externalRegistryHostnamePath...)
-	if err != nil {
-		return prevObservedConfig, append(errs, err)
-	}
-
-	return observedConfig, errs
-}
-
-func ObserveAllowedRegistriesForImport(genericListers configobserver.Listers, existingConfig map[string]interface{}) (map[string]interface{}, []error) {
-	listers := genericListers.(configobservation.Listers)
-	var errs []error
-	prevObservedConfig := map[string]interface{}{}
-
-	// first observe all the existing config values so that if we get any errors
-	// we can at least return those.
-	allowedRegistriesForImportPath := []string{"imagePolicyConfig", "allowedRegistriesForImport"}
-	o, _, err := unstructured.NestedSlice(existingConfig, allowedRegistriesForImportPath...)
-	if err != nil {
-		return prevObservedConfig, append(errs, err)
-	}
-	err = unstructured.SetNestedSlice(prevObservedConfig, o, allowedRegistriesForImportPath...)
-	if err != nil {
-		return prevObservedConfig, append(errs, err)
-	}
-
-	if !listers.ImageConfigSynced() {
-		glog.Warning("images.config.openshift.io not synced")
-		return prevObservedConfig, errs
-	}
-
-	// now gather the cluster config and turn it into the observed config
-	observedConfig := map[string]interface{}{}
-	configImage, err := listers.ImageConfigLister.Get("cluster")
-	if errors.IsNotFound(err) {
-		glog.Warningf("image.config.openshift.io/cluster: not found")
-		return observedConfig, errs
-	}
-	if err != nil {
-		return prevObservedConfig, append(errs, err)
-	}
-
-	allowed, err := Convert(configImage.Spec.AllowedRegistriesForImport)
-	if err != nil {
-		return prevObservedConfig, append(errs, err)
-	}
-	err = unstructured.SetNestedField(observedConfig, allowed, allowedRegistriesForImportPath...)
-	if err != nil {
-		return prevObservedConfig, append(errs, err)
-	}
-
-	return observedConfig, errs
-}
-
-func Convert(o interface{}) (interface{}, error) {
-	if o == nil {
-		return nil, nil
-	}
-	buf := &bytes.Buffer{}
-	if err := json.NewEncoder(buf).Encode(o); err != nil {
-		return nil, err
-	}
-
-	ret := []interface{}{}
-	if err := json.NewDecoder(buf).Decode(&ret); err != nil {
-		return nil, err
-	}
-
-	return ret, nil
 }

--- a/pkg/operator/configobservation/images/observe_images_test.go
+++ b/pkg/operator/configobservation/images/observe_images_test.go
@@ -1,9 +1,6 @@
 package images
 
 import (
-	"bytes"
-	"encoding/json"
-	"reflect"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -12,192 +9,36 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
-
 	"github.com/openshift/cluster-openshift-apiserver-operator/pkg/operator/configobservation"
 )
 
-type imageConfigTest struct {
-	imageConfig                       *configv1.Image
-	expectedInternalRegistryHostname  string
-	expectedExternalRegistryHostnames []string
-	expectedAllowedRegistries         []configv1.RegistryLocation
-}
-
-func TestObserveImageConfig(t *testing.T) {
-
-	allowedRegistries := []configv1.RegistryLocation{
-		{
-			DomainName: "insecuredomain",
-			Insecure:   true,
+func TestObserveInternalRegistryHostname(t *testing.T) {
+	const (
+		expectedInternalRegistryHostname = "docker-registry.openshift-image-registry.svc.cluster.local:5000"
+	)
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	imageConfig := &configv1.Image{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
 		},
-		{
-			DomainName: "securedomain1",
-			Insecure:   true,
-		},
-		{
-			DomainName: "securedomain2",
+		Status: configv1.ImageStatus{
+			InternalRegistryHostname: expectedInternalRegistryHostname,
 		},
 	}
-
-	tests := []imageConfigTest{
-		{
-			imageConfig: &configv1.Image{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "cluster",
-				},
-				Status: configv1.ImageStatus{
-					InternalRegistryHostname: "docker-registry.openshift-image-registry.svc.cluster.local:5000",
-				},
-			},
-			expectedInternalRegistryHostname: "docker-registry.openshift-image-registry.svc.cluster.local:5000",
-		},
-		{
-			imageConfig: &configv1.Image{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "cluster",
-				},
-				Spec: configv1.ImageSpec{
-					ExternalRegistryHostnames: []string{"spec.external.host.com"},
-				},
-			},
-			expectedExternalRegistryHostnames: []string{"spec.external.host.com"},
-		},
-		{
-			imageConfig: &configv1.Image{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "cluster",
-				},
-				Status: configv1.ImageStatus{
-					ExternalRegistryHostnames: []string{"status.external.host.com"},
-				},
-			},
-			expectedExternalRegistryHostnames: []string{"status.external.host.com"},
-		},
-		{
-			imageConfig: &configv1.Image{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "cluster",
-				},
-				Spec: configv1.ImageSpec{
-					ExternalRegistryHostnames: []string{"spec.external.host.com"},
-				},
-				Status: configv1.ImageStatus{
-					ExternalRegistryHostnames: []string{"status.external.host.com"},
-				},
-			},
-			expectedExternalRegistryHostnames: []string{"spec.external.host.com", "status.external.host.com"},
-		},
-		{
-			imageConfig: &configv1.Image{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "cluster",
-				},
-				Spec: configv1.ImageSpec{
-					AllowedRegistriesForImport: allowedRegistries,
-				},
-			},
-			expectedAllowedRegistries: allowedRegistries,
-		},
-		{
-			imageConfig: &configv1.Image{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "cluster",
-				},
-				Spec: configv1.ImageSpec{
-					AllowedRegistriesForImport: []configv1.RegistryLocation{},
-				},
-			},
-			expectedAllowedRegistries: []configv1.RegistryLocation{},
-		},
+	indexer.Add(imageConfig)
+	listers := configobservation.Listers{
+		ImageConfigLister: configlistersv1.NewImageLister(indexer),
+		ImageConfigSynced: func() bool { return true },
 	}
-
-	for _, tc := range tests {
-		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
-		indexer.Add(tc.imageConfig)
-		listers := configobservation.Listers{
-			ImageConfigLister: configlistersv1.NewImageLister(indexer),
-			ImageConfigSynced: func() bool { return true },
-		}
-		unsyncedlisters := configobservation.Listers{
-			ImageConfigLister: configlistersv1.NewImageLister(indexer),
-			ImageConfigSynced: func() bool { return false },
-		}
-
-		result, errs := ObserveInternalRegistryHostname(listers, map[string]interface{}{})
-		if len(errs) != 0 {
-			t.Fatalf("unexpected error: %v", errs)
-		}
-		internalRegistryHostname, _, err := unstructured.NestedString(result, "imagePolicyConfig", "internalRegistryHostname")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if internalRegistryHostname != tc.expectedInternalRegistryHostname {
-			t.Errorf("expected internal registry hostname: %s, got %s", tc.expectedInternalRegistryHostname, internalRegistryHostname)
-		}
-
-		// When the cache is not synced, the result should be the previously observed
-		// configuration.
-		newResult, errs := ObserveInternalRegistryHostname(unsyncedlisters, result)
-		if len(errs) != 0 {
-			t.Fatalf("unexpected error: %v", errs)
-		}
-		if !reflect.DeepEqual(result, newResult) {
-			t.Errorf("got: \n%#v\nexpected: \n%#v", newResult, result)
-		}
-
-		result, errs = ObserveExternalRegistryHostnames(listers, map[string]interface{}{})
-		if len(errs) != 0 {
-			t.Fatalf("unexpected error: %v", errs)
-		}
-		o, _, err := unstructured.NestedSlice(result, "imagePolicyConfig", "externalRegistryHostnames")
-		buf := &bytes.Buffer{}
-		if err := json.NewEncoder(buf).Encode(o); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		externalRegistryHostnames := []string{}
-		if err := json.NewDecoder(buf).Decode(&externalRegistryHostnames); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if !reflect.DeepEqual(externalRegistryHostnames, tc.expectedExternalRegistryHostnames) {
-			t.Errorf("got: \n%#v\nexpected: \n%#v", externalRegistryHostnames, tc.expectedExternalRegistryHostnames)
-		}
-
-		// When the cache is not synced, the result should be the previously observed
-		// configuration.
-		newResult, errs = ObserveExternalRegistryHostnames(unsyncedlisters, result)
-		if len(errs) != 0 {
-			t.Fatalf("unexpected error: %v", errs)
-		}
-		if !reflect.DeepEqual(result, newResult) {
-			t.Errorf("got: \n%#v\nexpected: \n%#v", newResult, result)
-		}
-
-		result, errs = ObserveAllowedRegistriesForImport(listers, map[string]interface{}{})
-		if len(errs) != 0 {
-			t.Fatalf("unexpected error: %v", errs)
-		}
-		o, _, err = unstructured.NestedSlice(result, "imagePolicyConfig", "allowedRegistriesForImport")
-		buf = &bytes.Buffer{}
-		if err := json.NewEncoder(buf).Encode(o); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		allowedRegistries := []configv1.RegistryLocation{}
-		if err := json.NewDecoder(buf).Decode(&allowedRegistries); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if !reflect.DeepEqual(allowedRegistries, tc.expectedAllowedRegistries) {
-			t.Errorf("got: \n%#v\nexpected: \n%#v", allowedRegistries, tc.expectedAllowedRegistries)
-		}
-
-		// When the cache is not synced, the result should be the previously observed
-		// configuration.
-		newResult, errs = ObserveAllowedRegistriesForImport(unsyncedlisters, result)
-		if len(errs) != 0 {
-			t.Fatalf("unexpected error: %v", errs)
-		}
-		if !reflect.DeepEqual(result, newResult) {
-			t.Errorf("got: \n%#v\nexpected: \n%#v", newResult, result)
-		}
+	result, errs := ObserveInternalRegistryHostname(listers, map[string]interface{}{})
+	if len(errs) > 0 {
+		t.Error("expected len(errs) == 0")
 	}
-
+	internalRegistryHostname, _, err := unstructured.NestedString(result, "imagePolicyConfig", "internalRegistryHostname")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if internalRegistryHostname != expectedInternalRegistryHostname {
+		t.Errorf("expected internal registry hostname: %s, got %s", expectedInternalRegistryHostname, internalRegistryHostname)
+	}
 }


### PR DESCRIPTION
Reverts openshift/cluster-openshift-apiserver-operator#54

This is causing flapping in the observedConfig which is causing the specified config to change, which is causing the daemonset to rollout, which is causing availability problems on one node clusters.

@bparees we'll need a fix or we'll have to disable these.  perhaps not a full revert, but it's an option.
@openshift/sig-master @sanchezl this is what you hit


```yaml
apiVersion: openshiftapiserver.operator.openshift.io/v1alpha1
kind: OpenShiftAPIServerOperatorConfig
metadata:
  creationTimestamp: 2018-11-26T20:52:20Z
  generation: 349
  name: instance
  resourceVersion: "811915"
  selfLink: /apis/openshiftapiserver.operator.openshift.io/v1alpha1/openshiftapiserveroperatorconfigs/instance
  uid: 2a9e3a4b-f1bd-11e8-b824-f647a32e86d7
spec:
  managementState: Managed
  observedConfig:
    imagePolicyConfig:
      allowedRegistriesForImport: null
      externalRegistryHostnames: null
      internalRegistryHostname: image-registry.openshift-image-registry.svc.cluster.local:5000
  operandSpecs: null
  unsupportedConfigOverrides: null
status:
  conditions:
  - lastTransitionTime: null
    message: |-
      .imagePolicyConfig.allowedRegistriesForImport accessor error: <nil> is of the type <nil>, expected []interface{}
      .imagePolicyConfig.externalRegistryHostnames accessor error: <nil> is of the type <nil>, expected []interface{}
    reason: ConfigObservationError
    status: "True"
    type: ConfigObservationFailing
  - lastTransitionTime: 2018-11-26T20:52:25Z
    status: "False"
    type: WorkloadFailing
  generations:
  - group: apps
    hash: ""
    lastGeneration: 342
    name: apiserver
    namespace: openshift-apiserver
    resource: daemonsets
  observedGeneration: 344
  readyReplicas: 0
  version: ""
apiVersion: openshiftapiserver.operator.openshift.io/v1alpha1
kind: OpenShiftAPIServerOperatorConfig
metadata:
  creationTimestamp: 2018-11-26T20:52:20Z
  generation: 349
  name: instance
  resourceVersion: "811916"
  selfLink: /apis/openshiftapiserver.operator.openshift.io/v1alpha1/openshiftapiserveroperatorconfigs/instance
  uid: 2a9e3a4b-f1bd-11e8-b824-f647a32e86d7
spec:
  managementState: Managed
  observedConfig:
    imagePolicyConfig:
      allowedRegistriesForImport: null
      externalRegistryHostnames: null
      internalRegistryHostname: image-registry.openshift-image-registry.svc.cluster.local:5000
  operandSpecs: null
  unsupportedConfigOverrides: null
status:
  conditions:
  - lastTransitionTime: null
    status: "False"
    type: ConfigObservationFailing
  - lastTransitionTime: 2018-11-26T20:52:25Z
    status: "False"
    type: WorkloadFailing
  generations:
  - group: apps
    hash: ""
    lastGeneration: 342
    name: apiserver
    namespace: openshift-apiserver
    resource: daemonsets
  observedGeneration: 344
  readyReplicas: 0
  version: ""







apiVersion: openshiftapiserver.operator.openshift.io/v1alpha1
kind: OpenShiftAPIServerOperatorConfig
metadata:
  creationTimestamp: 2018-11-26T20:52:20Z
  generation: 350
  name: instance
  resourceVersion: "812204"
  selfLink: /apis/openshiftapiserver.operator.openshift.io/v1alpha1/openshiftapiserveroperatorconfigs/instance
  uid: 2a9e3a4b-f1bd-11e8-b824-f647a32e86d7
spec:
  managementState: Managed
  observedConfig:
    imagePolicyConfig:
      internalRegistryHostname: image-registry.openshift-image-registry.svc.cluster.local:5000
  operandSpecs: null
  unsupportedConfigOverrides: null
status:
  conditions:
  - lastTransitionTime: null
    status: "False"
    type: ConfigObservationFailing
  - lastTransitionTime: 2018-11-26T20:52:25Z
    status: "False"
    type: WorkloadFailing
  generations:
  - group: apps
    hash: ""
    lastGeneration: 342
    name: apiserver
    namespace: openshift-apiserver
    resource: daemonsets
  observedGeneration: 344
  readyReplicas: 0
  version: ""
apiVersion: openshiftapiserver.operator.openshift.io/v1alpha1
kind: OpenShiftAPIServerOperatorConfig
metadata:
  creationTimestamp: 2018-11-26T20:52:20Z
  generation: 350
  name: instance
  resourceVersion: "812205"
  selfLink: /apis/openshiftapiserver.operator.openshift.io/v1alpha1/openshiftapiserveroperatorconfigs/instance
  uid: 2a9e3a4b-f1bd-11e8-b824-f647a32e86d7
spec:
  managementState: Managed
  observedConfig:
    imagePolicyConfig:
      internalRegistryHostname: image-registry.openshift-image-registry.svc.cluster.local:5000
  operandSpecs: null
  unsupportedConfigOverrides: null
status:
  conditions:
  - lastTransitionTime: null
    message: |-
      .imagePolicyConfig.allowedRegistriesForImport accessor error: <nil> is of the type <nil>, expected []interface{}
      .imagePolicyConfig.externalRegistryHostnames accessor error: <nil> is of the type <nil>, expected []interface{}
    reason: ConfigObservationError
    status: "True"
    type: ConfigObservationFailing
  - lastTransitionTime: 2018-11-26T20:52:25Z
    status: "False"
    type: WorkloadFailing
  generations:
  - group: apps
    hash: ""
    lastGeneration: 342
    name: apiserver
    namespace: openshift-apiserver
    resource: daemonsets
  observedGeneration: 344
  readyReplicas: 0
  version: ""

```