### PR TITLE
remove flapping config observation

### DIFF
--- a/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
+++ b/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
@@ -38,8 +38,9 @@ func NewConfigObserver(
 				},
 			},
 			images.ObserveInternalRegistryHostname,
-			images.ObserveExternalRegistryHostnames,
-			images.ObserveAllowedRegistriesForImport,
+			// TODO re-enable once flapping has been sorted out.
+			//images.ObserveExternalRegistryHostnames,
+			//images.ObserveAllowedRegistriesForImport,
 		),
 	}
 	operatorConfigInformers.Openshiftapiserver().V1alpha1().OpenShiftAPIServerOperatorConfigs().Informer().AddEventHandler(c.EventHandler())


### PR DESCRIPTION
A temporary measure to eliminate flapping. Related to https://github.com/openshift/cluster-openshift-apiserver-operator/pull/69 and https://github.com/openshift/cluster-openshift-apiserver-operator/pull/64

/assign @bparees 