### PR TITLE
add memory request to openshift-apiserver and operator pods

### DIFF
--- a/bindata/v3.11.0/openshift-apiserver/ds.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/ds.yaml
@@ -29,6 +29,9 @@ spec:
         command: ["hypershift", "openshift-apiserver"]
         args:
         - "--config=/var/run/configmaps/config/config.yaml"
+        resources:
+          requests:
+            memory: 200Mi
         ports:
         - containerPort: 8443
         volumeMounts:

--- a/manifests/0000_20_cluster-openshift-apiserver-operator_07_deployment.yaml
+++ b/manifests/0000_20_cluster-openshift-apiserver-operator_07_deployment.yaml
@@ -25,6 +25,9 @@ spec:
         args:
         - "--config=/var/run/configmaps/config/config.yaml"
         - "-v=2"
+        resources:
+          requests:
+            memory: 50Mi
         volumeMounts:
         - mountPath: /var/run/configmaps/config
           name: config

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -153,6 +153,9 @@ spec:
         command: ["hypershift", "openshift-apiserver"]
         args:
         - "--config=/var/run/configmaps/config/config.yaml"
+        resources:
+          requests:
+            memory: 200Mi
         ports:
         - containerPort: 8443
         volumeMounts:


### PR DESCRIPTION
One in a series of PRs to set memory requests for all control plane and high memory use components.

We are encountering master instability (https://github.com/openshift/installer/pull/408 https://github.com/openshift/installer/pull/785) as the number of components increase because many components run `BestEffort` giving the scheduler no information on pod resource usage.

On a steady state empty cluster, `openshift-apiserver` uses 179Mi.

{pod_name="apiserver-t5v2d"} | 179249152

Because it is a control plane component, I'm giving it a buffer and setting to `200Mi`

@deads2k @sttts  @derekwaynecarr