### PR TITLE
copy cluster image CAs to api server configmap

### DIFF
--- a/bindata/v3.11.0/openshift-apiserver/ds.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/ds.yaml
@@ -41,6 +41,8 @@ spec:
           name: client-ca
         - mountPath: /var/run/configmaps/etcd-serving-ca
           name: etcd-serving-ca
+        - mountPath: /var/run/configmaps/image-import-ca
+          name: image-import-ca
         - mountPath: /var/run/secrets/etcd-client
           name: etcd-client
         - mountPath: /var/run/secrets/serving-cert
@@ -67,6 +69,10 @@ spec:
       - name: etcd-serving-ca
         configMap:
           name: etcd-serving-ca
+      - name: image-import-ca
+        configMap:
+          name: image-import-ca
+          optional: true
       - name: etcd-client
         secret:
           secretName: etcd-client

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -58,6 +58,7 @@ func RunOperator(controllerContext *controllercmd.ControllerContext) error {
 	kubeInformersForOpenShiftAPIServerNamespace := kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, 10*time.Minute, kubeinformers.WithNamespace(targetNamespaceName))
 	kubeInformersForKubeAPIServerNamespace := kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, 10*time.Minute, kubeinformers.WithNamespace(kubeAPIServerNamespaceName))
 	kubeInformersForEtcdNamespace := kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, 10*time.Minute, kubeinformers.WithNamespace(etcdNamespaceName))
+	kubeInformersForOpenShiftConfigNamespace := kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, 10*time.Minute, kubeinformers.WithNamespace(openshiftConfigNamespaceName))
 	apiregistrationInformers := apiregistrationinformers.NewSharedInformerFactory(apiregistrationv1Client, 10*time.Minute)
 	configInformers := configinformers.NewSharedInformerFactory(configClient, 10*time.Minute)
 
@@ -72,8 +73,11 @@ func RunOperator(controllerContext *controllercmd.ControllerContext) error {
 		kubeInformersForOpenShiftAPIServerNamespace,
 		kubeInformersForEtcdNamespace,
 		kubeInformersForKubeAPIServerNamespace,
+		kubeInformersForOpenShiftConfigNamespace,
 		apiregistrationInformers,
+		configInformers,
 		operatorConfigClient.OpenshiftapiserverV1alpha1(),
+		configClient.ConfigV1(),
 		kubeClient,
 		apiregistrationv1Client.ApiregistrationV1(),
 		controllerContext.EventRecorder,

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -165,6 +165,8 @@ spec:
           name: client-ca
         - mountPath: /var/run/configmaps/etcd-serving-ca
           name: etcd-serving-ca
+        - mountPath: /var/run/configmaps/image-import-ca
+          name: image-import-ca
         - mountPath: /var/run/secrets/etcd-client
           name: etcd-client
         - mountPath: /var/run/secrets/serving-cert
@@ -191,6 +193,10 @@ spec:
       - name: etcd-serving-ca
         configMap:
           name: etcd-serving-ca
+      - name: image-import-ca
+        configMap:
+          name: image-import-ca
+          optional: true
       - name: etcd-client
         secret:
           secretName: etcd-client


### PR DESCRIPTION
1) watch the image.config.openshift.io and the configmap it references as a source of additional CAs to trust for image import.

2) sync that configmap into the openshift-apiserver namespace and mount the configmap into the apiserver pod.  CAs will be consumed by the imageimport logic inside the apiserver (work to be done in origin).

