### PR TITLE
Revert "add clusteroperator resource to CVO payload"

### DIFF
--- a/manifests/0000_20_cluster-openshift-apiserver-operator_08_clusteroperator.yaml
+++ b/manifests/0000_20_cluster-openshift-apiserver-operator_08_clusteroperator.yaml
@@ -1,5 +1,0 @@
-apiVersion: config.openshift.io/v1
-kind: ClusterOperator
-metadata:
-  name: openshift-cluster-openshift-apiserver-operator
-spec: {}


### PR DESCRIPTION
This reverts commit a07dc5caaa4bdb13513a28bb2382464520580ab1.

For more info https://github.com/openshift/cluster-kube-apiserver-operator/pull/167

/cc @deads2k 