### PR TITLE
Set terminationGracePeriodSeconds for enough graceful termination time

### DIFF
--- a/bindata/v3.11.0/openshift-apiserver/ds.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/ds.yaml
@@ -59,6 +59,7 @@ spec:
             scheme: HTTPS
             port: 8443
             path: healthz
+      terminationGracePeriodSeconds: 70 # a bit more than the 60 seconds timeout of non-long-running requests
       volumes:
       - name: config
         configMap:

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -183,6 +183,7 @@ spec:
             scheme: HTTPS
             port: 8443
             path: healthz
+      terminationGracePeriodSeconds: 70 # a bit more than the 60 seconds timeout of non-long-running requests
       volumes:
       - name: config
         configMap:


### PR DESCRIPTION
The apiserver waits up to 60 seconds for pending non-long-running requests to finish. We should wait as least as long for graceful termination to finally terminate the pod with SIGKILL.