### PR TITLE
wip: fix the cert name

### DIFF
--- a/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
+++ b/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
@@ -34,7 +34,7 @@ func NewResourceSyncController(
 	}
 	if err := resourceSyncController.SyncConfigMap(
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespaceName, Name: "client-ca"},
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.KubeAPIServerNamespaceName, Name: "client-ca"},
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.MachineSpecifiedGlobalConfigNamespace, Name: "kube-apiserver-client-ca"},
 	); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
kube-apiserver-operator:
```
2019-01-22 11:24:17 +0100 CET  ConfigMapCreated             Created ConfigMap/kube-apiserver-client-ca -n openshift-config-managed because it was missing
2019-01-22 11:25:47 +0100 CET  ConfigMapCreated             Created ConfigMap/aggregator-client-ca-3 -n openshift-kube-apiserver because it was missing
2019-01-22 11:25:48 +0100 CET  ConfigMapCreated             Created ConfigMap/client-ca-3 -n openshift-kube-apiserver because it was missing
```

openshift-apiserver-operator:
```
2019-01-22 11:27:48 +0100 CET  ConfigMapCreated             Created ConfigMap/client-ca -n openshift-apiserver because it was missing
```

@deads2k please confirm I'm wrong and we sync the right config map.