### PR TITLE
 add a check that actually attempts to hit the openshift api discovery

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/openshift/cluster-openshift-apiserver-operator/pkg/operator/workloadcontroller"
+
 	"github.com/openshift/cluster-openshift-apiserver-operator/pkg/operator/operatorclient"
 	"github.com/openshift/cluster-openshift-apiserver-operator/pkg/operator/resourcesynccontroller"
 
@@ -27,10 +29,6 @@ import (
 	"github.com/openshift/cluster-openshift-apiserver-operator/pkg/operator/configobservation/configobservercontroller"
 	"github.com/openshift/cluster-openshift-apiserver-operator/pkg/operator/v311_00_assets"
 	"github.com/openshift/library-go/pkg/operator/status"
-)
-
-const (
-	workQueueKey = "key"
 )
 
 func RunOperator(ctx *controllercmd.ControllerContext) error {
@@ -89,7 +87,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 		return err
 	}
 
-	workloadController := NewWorkloadController(
+	workloadController := workloadcontroller.NewWorkloadController(
 		os.Getenv("IMAGE"),
 		operatorConfigInformers.Openshiftapiserver().V1alpha1().OpenShiftAPIServerOperatorConfigs(),
 		kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespaceName),

--- a/pkg/operator/workloadcontroller/apigroup.go
+++ b/pkg/operator/workloadcontroller/apigroup.go
@@ -1,0 +1,25 @@
+package workloadcontroller
+
+import (
+	"fmt"
+	"net/http"
+
+	"k8s.io/client-go/rest"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func checkForAPIs(restclient rest.Interface, groupVersions ...schema.GroupVersion) []string {
+	missingMessages := []string{}
+	for _, groupVersion := range groupVersions {
+		url := "/apis/" + groupVersion.Group + "/" + groupVersion.Version
+
+		statusCode := 0
+		restclient.Get().AbsPath(url).Do().StatusCode(&statusCode)
+		if statusCode != http.StatusOK {
+			missingMessages = append(missingMessages, fmt.Sprintf("%s.%s is not ready: %v", groupVersion.Version, groupVersion.Group, statusCode))
+		}
+	}
+
+	return missingMessages
+}

--- a/pkg/operator/workloadcontroller/workload_controller.go
+++ b/pkg/operator/workloadcontroller/workload_controller.go
@@ -1,4 +1,4 @@
-package operator
+package workloadcontroller
 
 import (
 	"fmt"
@@ -34,6 +34,7 @@ import (
 const (
 	workloadFailingCondition = "WorkloadFailing"
 	imageImportCAName        = "image-import-ca"
+	workQueueKey             = "key"
 )
 
 type OpenShiftAPIServerOperator struct {

--- a/pkg/operator/workloadcontroller/workload_controller_openshiftapiserver_v311_00.go
+++ b/pkg/operator/workloadcontroller/workload_controller_openshiftapiserver_v311_00.go
@@ -1,4 +1,4 @@
-package operator
+package workloadcontroller
 
 import (
 	"fmt"

--- a/pkg/operator/workloadcontroller/workload_controller_openshiftapiserver_v311_00_test.go
+++ b/pkg/operator/workloadcontroller/workload_controller_openshiftapiserver_v311_00_test.go
@@ -1,4 +1,4 @@
-package operator
+package workloadcontroller
 
 import (
 	"sort"


### PR DESCRIPTION
Long ago, past me hit a problem in the aggregator that I suspected was openapi taking a long time.  We would transition an apiservice to available, but the proxy wasn't ready.  This does an actual check against the kube-apiserver to wait for them all to respond.


ref https://github.com/openshift/origin/blob/release-3.11/pkg/oc/clusteradd/componentinstall/readiness_apigroup.go