### PR TITLE
add related apiservices

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -119,13 +119,16 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 
 	clusterOperatorStatus := status.NewClusterOperatorStatusController(
 		"openshift-apiserver",
-		[]configv1.ObjectReference{
-			{Group: "openshiftapiserver.operator.openshift.io", Resource: "openshiftapiserveroperatorconfigs", Name: "cluster"},
-			{Resource: "namespaces", Name: operatorclient.UserSpecifiedGlobalConfigNamespace},
-			{Resource: "namespaces", Name: operatorclient.MachineSpecifiedGlobalConfigNamespace},
-			{Resource: "namespaces", Name: operatorclient.OperatorNamespace},
-			{Resource: "namespaces", Name: operatorclient.TargetNamespaceName},
-		},
+		append(
+			[]configv1.ObjectReference{
+				{Group: "openshiftapiserver.operator.openshift.io", Resource: "openshiftapiserveroperatorconfigs", Name: "cluster"},
+				{Resource: "namespaces", Name: operatorclient.UserSpecifiedGlobalConfigNamespace},
+				{Resource: "namespaces", Name: operatorclient.MachineSpecifiedGlobalConfigNamespace},
+				{Resource: "namespaces", Name: operatorclient.OperatorNamespace},
+				{Resource: "namespaces", Name: operatorclient.TargetNamespaceName},
+			},
+			workloadcontroller.APIServiceReferences()...,
+		),
 		configClient.ConfigV1(),
 		operatorClient,
 		status.NewVersionGetter(),

--- a/pkg/operator/workloadcontroller/apigroup.go
+++ b/pkg/operator/workloadcontroller/apigroup.go
@@ -6,8 +6,24 @@ import (
 
 	"k8s.io/client-go/rest"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
+
+var apiServiceGroupVersions = []schema.GroupVersion{
+	// these are all the apigroups we manage
+	{Group: "apps.openshift.io", Version: "v1"},
+	{Group: "authorization.openshift.io", Version: "v1"},
+	{Group: "build.openshift.io", Version: "v1"},
+	{Group: "image.openshift.io", Version: "v1"},
+	{Group: "oauth.openshift.io", Version: "v1"},
+	{Group: "project.openshift.io", Version: "v1"},
+	{Group: "quota.openshift.io", Version: "v1"},
+	{Group: "route.openshift.io", Version: "v1"},
+	{Group: "security.openshift.io", Version: "v1"},
+	{Group: "template.openshift.io", Version: "v1"},
+	{Group: "user.openshift.io", Version: "v1"},
+}
 
 func checkForAPIs(restclient rest.Interface, groupVersions ...schema.GroupVersion) []string {
 	missingMessages := []string{}
@@ -22,4 +38,12 @@ func checkForAPIs(restclient rest.Interface, groupVersions ...schema.GroupVersio
 	}
 
 	return missingMessages
+}
+
+func APIServiceReferences() []configv1.ObjectReference {
+	ret := []configv1.ObjectReference{}
+	for _, gv := range apiServiceGroupVersions {
+		ret = append(ret, configv1.ObjectReference{Group: "apiregistration.k8s.io", Resource: "apiservices", Name: gv.Version + "." + gv.Group})
+	}
+	return ret
 }

--- a/pkg/operator/workloadcontroller/workload_controller_openshiftapiserver_v311_00.go
+++ b/pkg/operator/workloadcontroller/workload_controller_openshiftapiserver_v311_00.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
 	appsclientv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
@@ -30,21 +29,6 @@ import (
 	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
-
-var apiServiceGroupVersions = []schema.GroupVersion{
-	// these are all the apigroups we manage
-	{Group: "apps.openshift.io", Version: "v1"},
-	{Group: "authorization.openshift.io", Version: "v1"},
-	{Group: "build.openshift.io", Version: "v1"},
-	{Group: "image.openshift.io", Version: "v1"},
-	{Group: "oauth.openshift.io", Version: "v1"},
-	{Group: "project.openshift.io", Version: "v1"},
-	{Group: "quota.openshift.io", Version: "v1"},
-	{Group: "route.openshift.io", Version: "v1"},
-	{Group: "security.openshift.io", Version: "v1"},
-	{Group: "template.openshift.io", Version: "v1"},
-	{Group: "user.openshift.io", Version: "v1"},
-}
 
 // syncOpenShiftAPIServer_v311_00_to_latest takes care of synchronizing (not upgrading) the thing we're managing.
 // most of the time the sync method will be good for a large span of minor versions


### PR DESCRIPTION
Add APIServices as related so that must-gather will pick them up for us and the webconsole can know we care about them too.

@eparis 
@juanvallejo 