### PR TITLE
always requeue on operator status that needs to be rechecked

### DIFF
--- a/pkg/operator/workloadcontroller/workload_controller_openshiftapiserver_v311_00.go
+++ b/pkg/operator/workloadcontroller/workload_controller_openshiftapiserver_v311_00.go
@@ -210,6 +210,16 @@ func syncOpenShiftAPIServer_v311_00_to_latest(c OpenShiftAPIServerOperator, orig
 	if len(errors) > 0 {
 		return true, nil
 	}
+	if !v1helpers.IsOperatorConditionFalse(operatorConfig.Status.Conditions, operatorv1.OperatorStatusTypeFailing) {
+		return true, nil
+	}
+	if !v1helpers.IsOperatorConditionFalse(operatorConfig.Status.Conditions, operatorv1.OperatorStatusTypeProgressing) {
+		return true, nil
+	}
+	if !v1helpers.IsOperatorConditionTrue(operatorConfig.Status.Conditions, operatorv1.OperatorStatusTypeAvailable) {
+		return true, nil
+	}
+
 	return false, nil
 }
 


### PR DESCRIPTION
Because the apiservices are listed as available, but aren't actually available, we need to requeue when our status isn't good.  This isn't quite like a resync. We only do this until we settle.


@eparis 