### PR TITLE
update to manage versions correctly

### DIFF
--- a/manifests/0000_61_openshift-apiserver-operator_03_version-mapping.yaml
+++ b/manifests/0000_61_openshift-apiserver-operator_03_version-mapping.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: openshift-apiserver-operator
+  name: version-mapping
+data:
+  "0.0.0_version_hypershift": "quay.io/openshift/origin-hypershift:v4.0"
+  "0.0.0_version_cluster-openshift-apiserver-operator": "docker.io/openshift/origin-cluster-openshift-apiserver-operator:v4.0"

--- a/manifests/0000_61_openshift-apiserver-operator_07_deployment.yaml
+++ b/manifests/0000_61_openshift-apiserver-operator_07_deployment.yaml
@@ -40,6 +40,8 @@ spec:
         env:
         - name: IMAGE
           value: quay.io/openshift/origin-hypershift:v4.0
+        - name: OPERATOR_IMAGE_VERSION
+          value: "0.0.0_version_cluster-openshift-apiserver-operator"
       volumes:
       - name: serving-cert
         secret:

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -84,8 +86,20 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 		return err
 	}
 
+	// don't change any versions until we sync
+	versionRecorder := status.NewVersionGetter()
+	clusterOperator, err := configClient.ConfigV1().ClusterOperators().Get("openshift-apiserver", metav1.GetOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	for _, version := range clusterOperator.Status.Versions {
+		versionRecorder.SetVersion(version.Name, version.Version)
+	}
+	versionRecorder.SetVersion("operator", os.Getenv("OPERATOR_IMAGE_VERSION"))
+
 	workloadController := workloadcontroller.NewWorkloadController(
 		os.Getenv("IMAGE"),
+		versionRecorder,
 		operatorConfigInformers.Operator().V1().OpenShiftAPIServers(),
 		kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespaceName),
 		kubeInformersForNamespaces.InformersFor(operatorclient.EtcdNamespaceName),
@@ -128,7 +142,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 		),
 		configClient.ConfigV1(),
 		operatorClient,
-		status.NewVersionGetter(),
+		versionRecorder,
 		ctx.EventRecorder,
 	)
 

--- a/pkg/operator/workloadcontroller/workload_controller.go
+++ b/pkg/operator/workloadcontroller/workload_controller.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/openshift/library-go/pkg/operator/status"
+
 	"github.com/openshift/cluster-openshift-apiserver-operator/pkg/operator/operatorclient"
 
 	"github.com/golang/glog"
@@ -39,6 +41,7 @@ const (
 
 type OpenShiftAPIServerOperator struct {
 	targetImagePullSpec string
+	versionRecorder     status.VersionGetter
 
 	operatorConfigClient    operatorv1client.OpenShiftAPIServersGetter
 	openshiftConfigClient   openshiftconfigclientv1.ConfigV1Interface
@@ -54,6 +57,7 @@ type OpenShiftAPIServerOperator struct {
 
 func NewWorkloadController(
 	targetImagePullSpec string,
+	versionRecorder status.VersionGetter,
 	operatorConfigInformer operatorv1informers.OpenShiftAPIServerInformer,
 	kubeInformersForOpenShiftAPIServerNamespace kubeinformers.SharedInformerFactory,
 	kubeInformersForEtcdNamespace kubeinformers.SharedInformerFactory,
@@ -68,7 +72,9 @@ func NewWorkloadController(
 	eventRecorder events.Recorder,
 ) *OpenShiftAPIServerOperator {
 	c := &OpenShiftAPIServerOperator{
-		targetImagePullSpec:     targetImagePullSpec,
+		targetImagePullSpec: targetImagePullSpec,
+		versionRecorder:     versionRecorder,
+
 		operatorConfigClient:    operatorConfigClient,
 		openshiftConfigClient:   openshiftConfigClient,
 		kubeClient:              kubeClient,

--- a/pkg/operator/workloadcontroller/workload_controller_openshiftapiserver_v311_00_test.go
+++ b/pkg/operator/workloadcontroller/workload_controller_openshiftapiserver_v311_00_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/openshift/library-go/pkg/operator/status"
+
 	"github.com/openshift/cluster-openshift-apiserver-operator/pkg/operator/operatorclient"
 
 	"github.com/pkg/errors"
@@ -144,6 +146,7 @@ func TestProgressingCondition(t *testing.T) {
 				operatorConfigClient:    apiServiceOperatorClient.OperatorV1(),
 				openshiftConfigClient:   openshiftConfigClient.ConfigV1(),
 				apiregistrationv1Client: kubeAggregatorClient.ApiregistrationV1(),
+				versionRecorder:         status.NewVersionGetter(),
 			}
 
 			_, _ = syncOpenShiftAPIServer_v311_00_to_latest(operator, operatorConfig)
@@ -372,6 +375,7 @@ func TestAvailableStatus(t *testing.T) {
 				operatorConfigClient:    apiServiceOperatorClient.OperatorV1(),
 				openshiftConfigClient:   openshiftConfigClient.ConfigV1(),
 				apiregistrationv1Client: kubeAggregatorClient.ApiregistrationV1(),
+				versionRecorder:         status.NewVersionGetter(),
 			}
 
 			_, _ = syncOpenShiftAPIServer_v311_00_to_latest(operator, operatorConfig)


### PR DESCRIPTION
This updates our operator to correctly report operand and operator versions in clusteroperator.status. It does this by relying the substitution value (@smarterclayton you're going to catch me on that right?) and (in the case of library-go), the watchable, thread-safe version application logic.

It also relies of the clever use of CVO merge logic (I think) to avoid overwriting all configmap keys so that I effectively keep a history of all the levels I've installed in the past.

@smarterclayton @bparees @ironcladlou 
@openshift/sig-master 