### PR TITLE
targetconfigcontroller: emit warning when management state is set to unknown value

### DIFF
--- a/pkg/operator/workloadcontroller/workload_controller.go
+++ b/pkg/operator/workloadcontroller/workload_controller.go
@@ -109,15 +109,19 @@ func (c OpenShiftAPIServerOperator) sync() error {
 	if err != nil {
 		return err
 	}
+
 	switch operatorConfig.Spec.ManagementState {
+	case operatorsv1.Managed:
 	case operatorsv1.Unmanaged:
 		return nil
-
 	case operatorsv1.Removed:
 		// TODO probably need to watch until the NS is really gone
 		if err := c.kubeClient.CoreV1().Namespaces().Delete(operatorclient.TargetNamespace, nil); err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
+		return nil
+	default:
+		c.eventRecorder.Warningf("ManagementStateUnknown", "Unrecognized operator management state %q", operatorConfig.Spec.ManagementState)
 		return nil
 	}
 


### PR DESCRIPTION
When the management state value is set to `foo`, we should stop managing and additionally emit a warning. We don't want to emit a warning per controller loop, so I added one to target config reconciler in each operator.