### PR TITLE
set project template reference namespace

### DIFF
--- a/pkg/cmd/resourcegraph/resourcegraph.go
+++ b/pkg/cmd/resourcegraph/resourcegraph.go
@@ -85,7 +85,7 @@ func Resources() resourcegraph.Resources {
 		Add(ret)
 
 	// aggregator CA
-	kasAggregatorCA := resourcegraph.NewConfigMap(operatorclient.GlobalMachineSpecifiedConfigNamespace, "kube-apiserver-aggregator-client-ca").
+	kasAggregatorCA := resourcegraph.NewConfigMap(operatorclient.GlobalUserSpecifiedConfigNamespace, "kube-apiserver-aggregator-client-ca").
 		Note("Synchronized").
 		From(kasOperator).
 		Add(ret)
@@ -95,7 +95,7 @@ func Resources() resourcegraph.Resources {
 		Add(ret)
 
 	// client CA
-	kasClientCA := resourcegraph.NewConfigMap(operatorclient.GlobalMachineSpecifiedConfigNamespace, "kube-apiserver-client-ca").
+	kasClientCA := resourcegraph.NewConfigMap(operatorclient.GlobalUserSpecifiedConfigNamespace, "kube-apiserver-client-ca").
 		Note("Synchronized").
 		From(kasOperator).
 		Add(ret)

--- a/pkg/operator/configobservation/project/observe_projects_test.go
+++ b/pkg/operator/configobservation/project/observe_projects_test.go
@@ -99,28 +99,27 @@ func TestObserveProjectRequestTemplateName(t *testing.T) {
 	}{
 		{
 			name:                 "simple update",
-			existingConfig:       map[string]interface{}{"projectConfig": map[string]interface{}{"projectRequestTemplate": "foo-template"}},
-			expectedConfig:       map[string]interface{}{"projectConfig": map[string]interface{}{"projectRequestTemplate": "bar-template"}},
+			existingConfig:       map[string]interface{}{"projectConfig": map[string]interface{}{"projectRequestTemplate": "openshift-config/foo-template"}},
+			expectedConfig:       map[string]interface{}{"projectConfig": map[string]interface{}{"projectRequestTemplate": "openshift-config/bar-template"}},
 			currentProjectConfig: fakeProjectConfig("cluster", projectv1.ProjectSpec{ProjectRequestTemplate: projectv1.TemplateReference{Name: "bar-template"}}),
 			expectEventCount:     1,
 		},
 		{
 			name:                 "empty field",
-			existingConfig:       map[string]interface{}{"projectConfig": map[string]interface{}{"projectRequestTemplate": "foo-template"}},
-			expectedConfig:       map[string]interface{}{"projectConfig": map[string]interface{}{"projectRequestTemplate": ""}},
+			existingConfig:       map[string]interface{}{"projectConfig": map[string]interface{}{"projectRequestTemplate": "openshift-config/foo-template"}},
 			currentProjectConfig: fakeProjectConfig("cluster", projectv1.ProjectSpec{ProjectRequestTemplate: projectv1.TemplateReference{Name: ""}}),
 			expectEventCount:     1,
 		},
 		{
 			name:                 "no existing",
-			expectedConfig:       map[string]interface{}{"projectConfig": map[string]interface{}{"projectRequestTemplate": "bar-template"}},
+			expectedConfig:       map[string]interface{}{"projectConfig": map[string]interface{}{"projectRequestTemplate": "openshift-config/bar-template"}},
 			currentProjectConfig: fakeProjectConfig("cluster", projectv1.ProjectSpec{ProjectRequestTemplate: projectv1.TemplateReference{Name: "bar-template"}}),
 			expectEventCount:     1,
 		},
 		{
 			name:                 "no change",
-			existingConfig:       map[string]interface{}{"projectConfig": map[string]interface{}{"projectRequestTemplate": "bar-template"}},
-			expectedConfig:       map[string]interface{}{"projectConfig": map[string]interface{}{"projectRequestTemplate": "bar-template"}},
+			existingConfig:       map[string]interface{}{"projectConfig": map[string]interface{}{"projectRequestTemplate": "openshift-config/bar-template"}},
+			expectedConfig:       map[string]interface{}{"projectConfig": map[string]interface{}{"projectRequestTemplate": "openshift-config/bar-template"}},
 			currentProjectConfig: fakeProjectConfig("cluster", projectv1.ProjectSpec{ProjectRequestTemplate: projectv1.TemplateReference{Name: "bar-template"}}),
 			expectEventCount:     0, // Do not fire events on no-op change
 		},

--- a/pkg/operator/operatorclient/interfaces.go
+++ b/pkg/operator/operatorclient/interfaces.go
@@ -2,9 +2,8 @@ package operatorclient
 
 const (
 	EtcdNamespaceName                     = "kube-system"
-	KubeAPIServerNamespaceName            = "openshift-kube-apiserver"
-	GlobalMachineSpecifiedConfigNamespace = "openshift-config"
-	MachineSpecifiedGlobalConfigNamespace = "openshift-config-managed"
+	GlobalUserSpecifiedConfigNamespace    = "openshift-config"
+	GlobalMachineSpecifiedConfigNamespace = "openshift-config-managed"
 	OperatorNamespace                     = "openshift-apiserver-operator"
 	TargetNamespace                       = "openshift-apiserver"
 )

--- a/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
+++ b/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
@@ -38,13 +38,13 @@ func NewResourceSyncController(
 	}
 	if err := resourceSyncController.SyncConfigMap(
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "client-ca"},
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.MachineSpecifiedGlobalConfigNamespace, Name: "kube-apiserver-client-ca"},
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace, Name: "kube-apiserver-client-ca"},
 	); err != nil {
 		return nil, err
 	}
 	if err := resourceSyncController.SyncConfigMap(
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "aggregator-client-ca"},
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.MachineSpecifiedGlobalConfigNamespace, Name: "kube-apiserver-aggregator-client-ca"},
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace, Name: "kube-apiserver-aggregator-client-ca"},
 	); err != nil {
 		return nil, err
 	}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -60,9 +60,8 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 	operatorConfigInformers := operatorv1informers.NewSharedInformerFactory(operatorConfigClient, 10*time.Minute)
 	kubeInformersForNamespaces := v1helpers.NewKubeInformersForNamespaces(kubeClient,
 		"",
+		operatorclient.GlobalUserSpecifiedConfigNamespace,
 		operatorclient.GlobalMachineSpecifiedConfigNamespace,
-		operatorclient.MachineSpecifiedGlobalConfigNamespace,
-		operatorclient.KubeAPIServerNamespaceName,
 		operatorclient.OperatorNamespace,
 		operatorclient.TargetNamespace,
 		"kube-system",
@@ -103,8 +102,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 		operatorConfigInformers.Operator().V1().OpenShiftAPIServers(),
 		kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace),
 		kubeInformersForNamespaces.InformersFor(operatorclient.EtcdNamespaceName),
-		kubeInformersForNamespaces.InformersFor(operatorclient.KubeAPIServerNamespaceName),
-		kubeInformersForNamespaces.InformersFor(operatorclient.GlobalMachineSpecifiedConfigNamespace),
+		kubeInformersForNamespaces.InformersFor(operatorclient.GlobalUserSpecifiedConfigNamespace),
 		apiregistrationInformers,
 		configInformers,
 		operatorConfigClient.OperatorV1(),
@@ -133,8 +131,8 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 		append(
 			[]configv1.ObjectReference{
 				{Group: "operator.openshift.io", Resource: "openshiftapiservers", Name: "cluster"},
+				{Resource: "namespaces", Name: operatorclient.GlobalUserSpecifiedConfigNamespace},
 				{Resource: "namespaces", Name: operatorclient.GlobalMachineSpecifiedConfigNamespace},
-				{Resource: "namespaces", Name: operatorclient.MachineSpecifiedGlobalConfigNamespace},
 				{Resource: "namespaces", Name: operatorclient.OperatorNamespace},
 				{Resource: "namespaces", Name: operatorclient.TargetNamespace},
 			},

--- a/pkg/operator/workloadcontroller/workload_controller.go
+++ b/pkg/operator/workloadcontroller/workload_controller.go
@@ -61,7 +61,6 @@ func NewWorkloadController(
 	operatorConfigInformer operatorv1informers.OpenShiftAPIServerInformer,
 	kubeInformersForOpenShiftAPIServerNamespace kubeinformers.SharedInformerFactory,
 	kubeInformersForEtcdNamespace kubeinformers.SharedInformerFactory,
-	kubeInformersForKubeAPIServerNamespace kubeinformers.SharedInformerFactory,
 	kubeInformersForOpenShiftConfigNamespace kubeinformers.SharedInformerFactory,
 	apiregistrationInformers apiregistrationinformers.SharedInformerFactory,
 	configInformers configinformers.SharedInformerFactory,
@@ -89,7 +88,6 @@ func NewWorkloadController(
 	operatorConfigInformer.Informer().AddEventHandler(c.eventHandler())
 	kubeInformersForEtcdNamespace.Core().V1().ConfigMaps().Informer().AddEventHandler(c.eventHandler())
 	kubeInformersForEtcdNamespace.Core().V1().Secrets().Informer().AddEventHandler(c.eventHandler())
-	kubeInformersForKubeAPIServerNamespace.Core().V1().ConfigMaps().Informer().AddEventHandler(c.eventHandler())
 	kubeInformersForOpenShiftAPIServerNamespace.Core().V1().ConfigMaps().Informer().AddEventHandler(c.eventHandler())
 	kubeInformersForOpenShiftAPIServerNamespace.Core().V1().ServiceAccounts().Informer().AddEventHandler(c.eventHandler())
 	kubeInformersForOpenShiftAPIServerNamespace.Core().V1().Services().Informer().AddEventHandler(c.eventHandler())

--- a/pkg/operator/workloadcontroller/workload_controller_openshiftapiserver_v311_00.go
+++ b/pkg/operator/workloadcontroller/workload_controller_openshiftapiserver_v311_00.go
@@ -238,7 +238,7 @@ func manageOpenShiftAPIServerImageImportCA_v311_00_to_latest(openshiftConfigClie
 		}
 		return true, nil
 	}
-	_, caChanged, err := resourceapply.SyncConfigMap(client, recorder, operatorclient.GlobalMachineSpecifiedConfigNamespace, imageConfig.Spec.AdditionalTrustedCA.Name, operatorclient.TargetNamespace, imageImportCAName, nil)
+	_, caChanged, err := resourceapply.SyncConfigMap(client, recorder, operatorclient.GlobalUserSpecifiedConfigNamespace, imageConfig.Spec.AdditionalTrustedCA.Name, operatorclient.TargetNamespace, imageImportCAName, nil)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1673155

The openshift-apiserver accepts a namspace/name format, but our operator managed config doesn't have that flexibility.  Force the namespace during config observation to bridge the gap.

/assign @mfojtik @soltysh 