### PR TITLE
remove artificial rate limits

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 91ecca14db72ab033857a2b198205b02d5e1c7fb571aaa9e32b9c0251e339ccd
-updated: 2019-02-19T19:36:28.209864056-05:00
+updated: 2019-02-20T16:26:36.390271459-05:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -231,7 +231,7 @@ imports:
 - name: github.com/NYTimes/gziphandler
   version: 56545f4a5d46df9a6648819d1664c3a03a13ffdb
 - name: github.com/openshift/api
-  version: 296f4c423703bb8b5b7e122cd4b3fc4153ef1130
+  version: cec6269883be26556e63500b6df19a0b6691992e
   subpackages:
   - apps
   - apps/v1
@@ -300,7 +300,7 @@ imports:
   - operator/informers/externalversions/operator/v1
   - operator/listers/operator/v1
 - name: github.com/openshift/library-go
-  version: d4be8d46e047d50dde25b0e36bd1bb6228e45cac
+  version: b8947b076480e6eb6939d81e080842348140a66f
   subpackages:
   - pkg/assets
   - pkg/config/client

--- a/pkg/operator/workloadcontroller/workload_controller.go
+++ b/pkg/operator/workloadcontroller/workload_controller.go
@@ -19,7 +19,6 @@ import (
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/client-go/util/workqueue"
 	apiregistrationv1client "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1"
 	apiregistrationinformers "k8s.io/kube-aggregator/pkg/client/informers/externalversions"
@@ -51,8 +50,6 @@ type OpenShiftAPIServerOperator struct {
 
 	// queue only ever has one item, but it has nice error handling backoff/retry semantics
 	queue workqueue.RateLimitingInterface
-
-	rateLimiter flowcontrol.RateLimiter
 }
 
 func NewWorkloadController(
@@ -82,8 +79,6 @@ func NewWorkloadController(
 		eventRecorder:           eventRecorder,
 
 		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "OpenShiftAPIServerOperator"),
-
-		rateLimiter: flowcontrol.NewTokenBucketRateLimiter(0.05 /*3 per minute*/, 4),
 	}
 
 	operatorConfigInformer.Informer().AddEventHandler(c.eventHandler())
@@ -182,9 +177,6 @@ func (c *OpenShiftAPIServerOperator) processNextWorkItem() bool {
 		return false
 	}
 	defer c.queue.Done(dsKey)
-
-	// before we call sync, we want to wait for token.  We do this to avoid hot looping.
-	c.rateLimiter.Accept()
 
 	err := c.sync()
 	if err == nil {

--- a/vendor/github.com/openshift/api/config/v1/types_console.go
+++ b/vendor/github.com/openshift/api/config/v1/types_console.go
@@ -24,9 +24,9 @@ type ConsoleSpec struct {
 }
 
 type ConsoleStatus struct {
-	// The hostname for the console. This will match the host for the route that
+	// The URL for the console. This will be derived from the host for the route that
 	// is created for the console.
-	PublicHostname string `json:"publicHostname"`
+	ConsoleURL string `json:"consoleURL"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/vendor/github.com/openshift/api/config/v1/zz_generated.swagger_doc_generated.go
+++ b/vendor/github.com/openshift/api/config/v1/zz_generated.swagger_doc_generated.go
@@ -564,7 +564,7 @@ func (ConsoleList) SwaggerDoc() map[string]string {
 }
 
 var map_ConsoleStatus = map[string]string{
-	"publicHostname": "The hostname for the console. This will match the host for the route that is created for the console.",
+	"consoleURL": "The URL for the console. This will be derived from the host for the route that is created for the console.",
 }
 
 func (ConsoleStatus) SwaggerDoc() map[string]string {

--- a/vendor/github.com/openshift/library-go/Makefile
+++ b/vendor/github.com/openshift/library-go/Makefile
@@ -2,7 +2,7 @@ all: build
 .PHONY: all
 
 # All the go packages (e.g. for verfy)
-GO_PACKAGES :=./pkg/...
+GO_PACKAGES :=./pkg/... ./cmd/...
 # Packages to be compiled
 GO_BUILD_PACKAGES :=$(GO_PACKAGES)
 # Do not auto-expand packages for libraries or it would compile them separately

--- a/vendor/github.com/openshift/library-go/cmd/crd-schema-gen/generator/generator.go
+++ b/vendor/github.com/openshift/library-go/cmd/crd-schema-gen/generator/generator.go
@@ -1,0 +1,281 @@
+package generator
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	crdgenerator "sigs.k8s.io/controller-tools/pkg/crd/generator"
+)
+
+var (
+	scheme = runtime.NewScheme()
+	codecs = serializer.NewCodecFactory(scheme)
+)
+
+func init() {
+	v1beta1.AddToScheme(scheme)
+}
+
+func Run() error {
+	apisDir := flag.String("apis-dir", "pkg/apis", "the (relative) path to the package with API definitions")
+	apis := flag.String("apis", "*", "the apis to generate from the apis-dir, in bash glob syntax")
+	manifestDir := flag.String("manifests-dir", "manifests", "the directory with existing CRD manifests")
+	outputDir := flag.String("output-dir", "", "optional directory to output the kubebuilder CRDs. By default a temporary directory is used.")
+	verifyOnly := flag.Bool("verify-only", false, "do not write files, only compare and return with return code 1 if dirty")
+
+	flag.Parse()
+
+	// load existing manifests from manifests/ dir
+	existing, err := crdsFromDirectory(*manifestDir)
+	if err != nil {
+		return err
+	}
+
+	// create temp dir
+	pwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	tmpDir, err := ioutil.TempDir(pwd, "")
+	if err != nil {
+		return fmt.Errorf("error creating temp directory: %v\n", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// copy APIs to temp dir
+	fmt.Printf("Copying vendor/github.com/openshift/api/config to temporary pkg/apis...\n")
+	if err := os.MkdirAll(filepath.Join(tmpDir, "pkg/apis"), 0755); err != nil {
+		return err
+	}
+	cmd := fmt.Sprintf("cp -av \"%s/\"%s \"%s\"", *apisDir, *apis, filepath.Join(tmpDir, "pkg/apis"))
+	out, err := exec.Command("/bin/bash", "-c", cmd).CombinedOutput()
+	if err != nil {
+		fmt.Print(string(out))
+		return err
+	}
+
+	// generate kubebuilder NamedYaml manifests into temp dir
+	g := crdgenerator.Generator{
+		RootPath:          tmpDir,
+		Domain:            "openshift.io",
+		OutputDir:         filepath.Join(tmpDir, "manifests"),
+		SkipMapValidation: true,
+	}
+
+	if len(*outputDir) != 0 {
+		g.OutputDir = *outputDir
+		fmt.Printf("Creating kubebuilder manifests %s...", *outputDir)
+	} else {
+		fmt.Printf("Creating kubebuilder manifests in ...\n")
+	}
+
+	if err := g.ValidateAndInitFields(); err != nil {
+		return err
+	}
+	if err := g.Do(); err != nil {
+		return err
+	}
+
+	// the generator changes the directory for some reason
+	os.Chdir(pwd)
+
+	// load kubebuilder manifests from temp dir
+	fromKubebuilder, err := crdsFromDirectory(g.OutputDir)
+	if err != nil {
+		return err
+	}
+
+	existingFileNames := map[string]string{}
+	for fn, crd := range existing {
+		existingFileNames[crd.Name] = fn
+	}
+
+	// update existing manifests with validations of kubebuilder output
+	dirty := false
+	for fn, withValidation := range fromKubebuilder {
+		existingFileName, ok := existingFileNames[withValidation.Name]
+		if !ok {
+			continue
+		}
+
+		crd := existing[existingFileName]
+		// TODO: support multiple versions
+		validation, _, err := nested(withValidation.Yaml, "spec", "validation")
+		if err != nil {
+			return fmt.Errorf("failed to access spec.validation in %s: %v", fn, err)
+		}
+		if validation == nil {
+			continue
+		}
+		updated, err := set(crd.Yaml, validation, "spec", "validation")
+		if err != nil {
+			return fmt.Errorf("failed to set spec.validation in %s: %v", existingFileName, err)
+		}
+		if reflect.DeepEqual(updated, crd.Yaml) {
+			fmt.Printf("Validation of %s in %s did not change\n", crd.Name, existingFileName)
+			continue
+		}
+
+		bs, err := yaml.Marshal(updated)
+		if err != nil {
+			return err
+		}
+
+		// write updated file, either to old location, or to temp dir in verify mode
+		newFn := existingFileName
+		if *verifyOnly {
+			newFn = filepath.Join(tmpDir, filepath.Base(existingFileName))
+		} else {
+			fmt.Printf("Updating validation of %s in %s\n", crd.Name, existingFileName)
+		}
+		if err := ioutil.WriteFile(newFn, bs, 0644); err != nil {
+			return err
+		}
+
+		// compare old and new file
+		if *verifyOnly {
+			out, err := exec.Command("diff", "-u", existingFileName, newFn).CombinedOutput()
+			if err != nil {
+				fmt.Println(string(out))
+				dirty = true
+			}
+		}
+	}
+
+	if *verifyOnly && dirty {
+		return fmt.Errorf("verification failed")
+	}
+
+	return nil
+}
+
+func nested(x interface{}, pth ...string) (interface{}, bool, error) {
+	if len(pth) == 0 {
+		return x, true, nil
+	}
+	m, ok := x.(yaml.MapSlice)
+	if !ok {
+		return nil, false, fmt.Errorf("%s is not an object, but %T", strings.Join(pth, "."), x)
+	}
+	for _, item := range m {
+		s, ok := item.Key.(string)
+		if !ok {
+			continue
+		}
+		if s == pth[0] {
+			ret, found, err := nested(item.Value, pth[1:]...)
+			if err != nil {
+				return ret, found, fmt.Errorf("%s.%s", pth[0], err)
+			}
+			return ret, found, nil
+		}
+	}
+	return nil, false, nil
+}
+
+func set(x interface{}, v interface{}, pth ...string) (interface{}, error) {
+	if len(pth) == 0 {
+		return v, nil
+	}
+
+	if x == nil {
+		result, err := set(nil, v, pth[1:]...)
+		if err != nil {
+			return nil, fmt.Errorf("%s.%s", pth[0], err)
+		}
+		return yaml.MapSlice{yaml.MapItem{Key: pth[0], Value: result}}, nil
+	}
+
+	m, ok := x.(yaml.MapSlice)
+	if !ok {
+		return nil, fmt.Errorf("%s is not an object", strings.Join(pth, "."))
+	}
+
+	foundAt := -1
+	for i, item := range m {
+		s, ok := item.Key.(string)
+		if !ok {
+			continue
+		}
+		if s == pth[0] {
+			foundAt = i
+			break
+		}
+	}
+
+	if foundAt < 0 {
+		ret := make(yaml.MapSlice, len(m), len(m)+1)
+		copy(ret, m)
+		result, err := set(nil, v, pth[1:]...)
+		if err != nil {
+			return nil, fmt.Errorf("%s.%s", pth[0], err)
+		}
+		return append(ret, yaml.MapItem{Key: pth[0], Value: result}), nil
+	}
+
+	result, err := set(m[foundAt].Value, v, pth[1:]...)
+	ret := make(yaml.MapSlice, len(m))
+	copy(ret, m)
+	if err != nil {
+		return nil, fmt.Errorf("%s.%s", pth[0], err)
+	}
+	ret[foundAt].Value = result
+	return ret, nil
+}
+
+type NamedYaml struct {
+	Name string
+	Yaml interface{}
+}
+
+// crdsFromDirectory returns CRDs by file path
+func crdsFromDirectory(dir string) (map[string]NamedYaml, error) {
+	ret := map[string]NamedYaml{}
+	infos, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	for _, info := range infos {
+		if info.IsDir() {
+			continue
+		}
+		if !strings.HasSuffix(info.Name(), ".yaml") {
+			continue
+		}
+		bs, err := ioutil.ReadFile(filepath.Join(dir, info.Name()))
+		if err != nil {
+			return nil, err
+		}
+
+		obj, _, err := codecs.UniversalDeserializer().Decode(bs, nil, nil)
+		if err != nil {
+			continue
+		}
+		crd, ok := obj.(*v1beta1.CustomResourceDefinition)
+		if !ok {
+			continue
+		}
+
+		var y yaml.MapSlice
+		if err := yaml.Unmarshal(bs, &y); err != nil {
+			fmt.Printf("Warning: failed to unmarshal %q, skipping\n", info.Name())
+			continue
+		}
+		ret[filepath.Join(dir, info.Name())] = NamedYaml{crd.Name, y}
+	}
+	if err != nil {
+		return nil, err
+	}
+	return ret, err
+}

--- a/vendor/github.com/openshift/library-go/cmd/crd-schema-gen/main.go
+++ b/vendor/github.com/openshift/library-go/cmd/crd-schema-gen/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/openshift/library-go/cmd/crd-schema-gen/generator"
+)
+
+func main() {
+	if err := generator.Run(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/vendor/github.com/openshift/library-go/glide.lock
+++ b/vendor/github.com/openshift/library-go/glide.lock
@@ -1,5 +1,5 @@
-hash: 6dba1fdcbca5b8cd27ff1f69ce80ee41c2c60087cbf3407dc847ac49e4878614
-updated: 2019-02-18T14:37:18.970240624-05:00
+hash: 4acbb62668470e66c8fd59b579e66a6797ae8012704d3adff2f72bcb8c10c9db
+updated: 2019-02-20T11:36:58.819388+01:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -131,6 +131,8 @@ imports:
   version: 1de3e0542de65ad8d75452a595886fdd0befb363
 - name: github.com/go-openapi/swag
   version: f3f9494671f93fcff853e3c6e9e948b3eb71e590
+- name: github.com/gobuffalo/envy
+  version: fa0dfdc10b5366ce365b7d9d1755a03e4e797bc5
 - name: github.com/gogo/protobuf
   version: c0656edd0d9eab7c66d1eb0c568f9039345796f7
   subpackages:
@@ -145,20 +147,22 @@ imports:
 - name: github.com/golang/protobuf
   version: b4deda0973fb4c70b50d226b1af49f3da59f5265
   subpackages:
+  - jsonpb
   - proto
   - protoc-gen-go/descriptor
   - ptypes
   - ptypes/any
   - ptypes/duration
+  - ptypes/struct
   - ptypes/timestamp
 - name: github.com/gonum/blas
-  version: f22b278b28ac9805aadd613a754a60c35b24ae69
+  version: 37e82626499e1df7c54aeaba0959fd6e7e8dc1e4
   subpackages:
   - blas64
   - native
   - native/internal/math32
 - name: github.com/gonum/floats
-  version: c233463c7e827fd71a8cdb62dfda0e98f7c39ad5
+  version: f74b330d45c56584a6ea7a27f5c64ea2900631e9
 - name: github.com/gonum/graph
   version: 50b27dea7ebbfb052dfaf91681afc6fde28d8796
   subpackages:
@@ -173,17 +177,17 @@ imports:
   - internal/ordered
   - simple
 - name: github.com/gonum/internal
-  version: f884aa71402950fb2796dbea0d5aa9ef9cfad8ca
+  version: e57e4534cf9b3b00ef6c0175f59d8d2d34f60914
   subpackages:
   - asm/f32
   - asm/f64
 - name: github.com/gonum/lapack
-  version: e4cdc5a0bff924bb10be88482e635bd40429f65e
+  version: 5ed4b826becd1807e09377508f51756586d1a98c
   subpackages:
   - lapack64
   - native
 - name: github.com/gonum/matrix
-  version: c518dec07be9a636c38a4650e217be059b5952ec
+  version: dd6034299e4242c9f0ea36735e6d4264dfcb3f9f
   subpackages:
   - mat64
 - name: github.com/google/btree
@@ -210,16 +214,22 @@ imports:
   version: 9316a62528ac99aaecb4e47eadd6dc8aa6533d58
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
+- name: github.com/joho/godotenv
+  version: 6d367c18edf6ca7fd004efd6863e4c5728fa858e
 - name: github.com/json-iterator/go
   version: f2b4162afba35581b6d4a50d3b8f34e33c144682
 - name: github.com/jteeuwen/go-bindata
   version: a0ff2567cfb70903282db057e799fd826784d41d
+- name: github.com/kr/fs
+  version: 2788f0dbd16903de03cb8186e5c7d97b69ad387b
 - name: github.com/mailru/easyjson
   version: 2f5df55504ebc322e4d52d34df6a1f5b503bf26d
   subpackages:
   - buffer
   - jlexer
   - jwriter
+- name: github.com/markbates/inflect
+  version: 24b83195037b3bc61fcda2d28b7b0518bce293b6
 - name: github.com/matttproud/golang_protobuf_extensions
   version: c12348ce28de40eed0136aa2b644d0ee0650e56c
   subpackages:
@@ -231,7 +241,7 @@ imports:
 - name: github.com/NYTimes/gziphandler
   version: 56545f4a5d46df9a6648819d1664c3a03a13ffdb
 - name: github.com/openshift/api
-  version: af79befc50a8223c8122e9e654f65763dd17a87e
+  version: 296f4c423703bb8b5b7e122cd4b3fc4153ef1130
   subpackages:
   - apps
   - apps/v1
@@ -292,6 +302,8 @@ imports:
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - name: github.com/pkg/profile
   version: 22592cc4bae3572d59be8852c6980023e4c9dec5
+- name: github.com/pkg/sftp
+  version: 4d0e916071f68db74f8a73926335f809396d6b42
 - name: github.com/prometheus/client_golang
   version: e7e903064f5e9eb5da98208bae10b475d4db0f8c
   subpackages:
@@ -314,10 +326,21 @@ imports:
   version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
 - name: github.com/PuerkitoBio/urlesc
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
+- name: github.com/rogpeppe/go-internal
+  version: 1cf9852c553c5b7da2d5a4a091129a7822fed0c9
+  subpackages:
+  - modfile
+  - module
+  - semver
 - name: github.com/sigma/go-inotify
   version: c87b6cf5033d2c6486046f045eeebdc3d910fd38
 - name: github.com/sirupsen/logrus
   version: 89742aefa4b206dcf400792f3bd35b542998eb3b
+- name: github.com/spf13/afero
+  version: b28a7effac979219c2a2ed6205a4d70e4b1bcd02
+  subpackages:
+  - mem
+  - sftp
 - name: github.com/spf13/cobra
   version: c439c4fa093711d42e1b01acb1235b52004753c1
 - name: github.com/spf13/pflag
@@ -329,13 +352,20 @@ imports:
 - name: golang.org/x/crypto
   version: de0752318171da717af4ce24d0a2e8626afaeb11
   subpackages:
+  - bcrypt
+  - blowfish
+  - curve25519
+  - ed25519
+  - ed25519/internal/edwards25519
+  - internal/chacha20
+  - internal/subtle
+  - poly1305
+  - ssh
   - ssh/terminal
 - name: golang.org/x/net
   version: 0ed95abb35c445290478a5348a7b38bb154135fd
   subpackages:
   - context
-  - html
-  - html/atom
   - http2
   - http2/hpack
   - idna
@@ -346,10 +376,7 @@ imports:
 - name: golang.org/x/oauth2
   version: a6bd8cefa1811bd24b86f8902872e4e8225f74c4
   subpackages:
-  - google
   - internal
-  - jws
-  - jwt
 - name: golang.org/x/sys
   version: 95c6576299259db960f6c5b9b69ea52422860fce
   subpackages:
@@ -374,11 +401,13 @@ imports:
   subpackages:
   - rate
 - name: golang.org/x/tools
-  version: 8dcb7bc8c7fe0a895995c76c721cef79419ac98a
+  version: 2382e3994d48b1d22acc2c86bcad0a2aff028e32
   subpackages:
   - container/intsets
+  - go/ast/astutil
+  - imports
 - name: google.golang.org/appengine
-  version: 54a98f90d1c46b7731eb8fb305d2a321c30ef610
+  version: 12d5545dc1cfa6047a286d5e853841b6471f4c19
   subpackages:
   - internal
   - internal/base
@@ -782,6 +811,14 @@ imports:
   - util/integer
   - util/retry
   - util/workqueue
+- name: k8s.io/gengo
+  version: 4242d8e6c5dba56827bb7bcf14ad11cda38f3991
+  subpackages:
+  - args
+  - generator
+  - namer
+  - parser
+  - types
 - name: k8s.io/kube-aggregator
   version: 4764f3a1991175f477682bbba516e97fab77b19f
   subpackages:
@@ -798,8 +835,17 @@ imports:
   - pkg/handler
   - pkg/util
   - pkg/util/proto
+- name: sigs.k8s.io/controller-tools
+  version: 447efe98e33eff8432a9dbc046828d9033021295
+  subpackages:
+  - pkg/crd/generator
+  - pkg/crd/util
+  - pkg/internal/codegen
+  - pkg/internal/codegen/parse
+  - pkg/internal/general
+  - pkg/util
 testImports:
 - name: vbom.ml/util
-  version: efcd4e0f97874370259c7d93e12aad57911dea81
+  version: db5cfe13f5cc80a4990d98e2e1b0707a4d1a5394
   subpackages:
   - sortorder

--- a/vendor/github.com/openshift/library-go/glide.yaml
+++ b/vendor/github.com/openshift/library-go/glide.yaml
@@ -17,6 +17,11 @@ import:
 - package: github.com/openshift/client-go
   version: master
 
+# crd-schema-gen
+- package: sigs.k8s.io/controller-tools
+  version: 447efe98e33eff8432a9dbc046828d9033021295
+- package: k8s.io/gengo
+  version: 4242d8e6c5dba56827bb7bcf14ad11cda38f3991
 
 # sig-master - needed for file observer
 - package: github.com/sigma/go-inotify

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/config_observer_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/config_observer_controller.go
@@ -16,7 +16,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/client-go/util/workqueue"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -48,7 +47,6 @@ type ConfigObserver struct {
 	// queue only ever has one item, but it has nice error handling backoff/retry semantics
 	queue workqueue.RateLimitingInterface
 
-	rateLimiter flowcontrol.RateLimiter
 	// observers are called in an undefined order and their results are merged to
 	// determine the observed configuration.
 	observers []ObserveConfigFunc
@@ -69,9 +67,8 @@ func NewConfigObserver(
 
 		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "ConfigObserver"),
 
-		rateLimiter: flowcontrol.NewTokenBucketRateLimiter(0.05 /*3 per minute*/, 4),
-		observers:   observers,
-		listers:     listers,
+		observers: observers,
+		listers:   listers,
 	}
 }
 
@@ -172,9 +169,6 @@ func (c *ConfigObserver) processNextWorkItem() bool {
 		return false
 	}
 	defer c.queue.Done(dsKey)
-
-	// before we call sync, we want to wait for token.  We do this to avoid hot looping.
-	c.rateLimiter.Accept()
 
 	err := c.sync()
 	if err == nil {

--- a/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/resourcesync_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/resourcesync_controller.go
@@ -135,10 +135,13 @@ func (c *ResourceSyncController) sync() error {
 	}
 
 	switch operatorSpec.ManagementState {
+	case operatorv1.Managed:
 	case operatorv1.Unmanaged:
 		return nil
 	case operatorv1.Removed:
-		// TODO: Should we try to actively remove the resources created by this controller here?
+		// TODO probably just fail
+		return nil
+	default:
 		return nil
 	}
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/backingresource/backing_resource_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/backingresource/backing_resource_controller.go
@@ -98,10 +98,13 @@ func (c BackingResourceController) sync() error {
 	}
 
 	switch operatorSpec.ManagementState {
+	case operatorv1.Managed:
 	case operatorv1.Unmanaged:
 		return nil
 	case operatorv1.Removed:
-		// TODO: Should we delete the installer-sa and cluster role binding?
+		// TODO probably just fail
+		return nil
+	default:
 		return nil
 	}
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -668,12 +668,16 @@ func (c InstallerController) sync() error {
 	operatorStatus := originalOperatorStatus.DeepCopy()
 
 	switch operatorSpec.ManagementState {
+	case operatorv1.Managed:
 	case operatorv1.Unmanaged:
 		return nil
 	case operatorv1.Removed:
-		// TODO probably just fail.  Static pod managers can't be removed.
+		// TODO probably just fail
+		return nil
+	default:
 		return nil
 	}
+
 	requeue, syncErr := c.manageInstallationPods(operatorSpec, operatorStatus, resourceVersion)
 	if requeue && syncErr == nil {
 		return fmt.Errorf("synthetic requeue request")

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/monitoring/monitoring_resource_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/monitoring/monitoring_resource_controller.go
@@ -99,10 +99,13 @@ func (c MonitoringResourceController) sync() error {
 	}
 
 	switch operatorSpec.ManagementState {
+	case operatorv1.Managed:
 	case operatorv1.Unmanaged:
 		return nil
 	case operatorv1.Removed:
-		// TODO: Should we try to actively remove the resources created by this controller here?
+		// TODO probably just fail
+		return nil
+	default:
 		return nil
 	}
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/revision/revision_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/revision/revision_controller.go
@@ -234,10 +234,13 @@ func (c RevisionController) sync() error {
 	operatorStatus := originalOperatorStatus.DeepCopy()
 
 	switch operatorSpec.ManagementState {
+	case operatorv1.Managed:
 	case operatorv1.Unmanaged:
 		return nil
 	case operatorv1.Removed:
-		// TODO probably just fail.  Static pod managers can't be removed.
+		// TODO probably just fail
+		return nil
+	default:
 		return nil
 	}
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/staticpodstate/staticpodstate_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/staticpodstate/staticpodstate_controller.go
@@ -84,10 +84,13 @@ func (c *StaticPodStateController) sync() error {
 	}
 
 	switch operatorSpec.ManagementState {
+	case operatorv1.Managed:
 	case operatorv1.Unmanaged:
 		return nil
 	case operatorv1.Removed:
-		// TODO probably just fail.  Static pod managers can't be removed.
+		// TODO probably just fail
+		return nil
+	default:
 		return nil
 	}
 


### PR DESCRIPTION
we introduced these when we had stability concerns.  We can remove them to gain some performance and chase down any rogue actors.

we agreed in slack already.