### PR TITLE
Set minimal-shutdown-duration to 3s

### DIFF
--- a/bindata/v3.11.0/openshift-apiserver/defaultconfig.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/defaultconfig.yaml
@@ -43,3 +43,6 @@ auditConfig:
         # generate an audit event in RequestReceived.
         omitStages:
           - "RequestReceived"
+apiServerArguments:
+  minimal-shutdown-duration:
+  - 3s # give SDN some time to converge

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -148,7 +148,9 @@ auditConfig:
         # generate an audit event in RequestReceived.
         omitStages:
           - "RequestReceived"
-`)
+apiServerArguments:
+  minimal-shutdown-duration:
+  - 3s # give SDN some time to converge`)
 
 func v3110OpenshiftApiserverDefaultconfigYamlBytes() ([]byte, error) {
 	return _v3110OpenshiftApiserverDefaultconfigYaml, nil


### PR DESCRIPTION
The SDN needs some time to converge when endpoints change. This minimal shutdown time delay the actual shutdown (and stop of serving) to avoid that race.