### PR TITLE
operator: use proto client for api registration client

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -35,7 +35,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 	if err != nil {
 		return err
 	}
-	apiregistrationv1Client, err := apiregistrationclient.NewForConfig(ctx.KubeConfig)
+	apiregistrationv1Client, err := apiregistrationclient.NewForConfig(ctx.ProtoKubeConfig)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I believe proto client is safe for api registration client and informer. The JSON client showed up in prometheus metrics and this is low hanging fruit.

/cc @deads2k 