### PR TITLE
manifests: system-cluster-critical priority for operator

### DIFF
--- a/manifests/0000_61_openshift-apiserver-operator_07_deployment.yaml
+++ b/manifests/0000_61_openshift-apiserver-operator_07_deployment.yaml
@@ -53,5 +53,6 @@ spec:
           name: openshift-apiserver-operator-config
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      priorityClassName: "system-cluster-critical"
       tolerations:
       - operator: Exists


### PR DESCRIPTION
specifies system-cluster-critical priority for operators that run on masters.
blocks passing smoke tests for ensuring control plane pods always schedule.

see: openshift/origin#22217