### PR TITLE
use dynamic reloading of certs to avoid rolling out new deployment versions

### DIFF
--- a/pkg/operator/workloadcontroller/workload_controller_openshiftapiserver_v311_00.go
+++ b/pkg/operator/workloadcontroller/workload_controller_openshiftapiserver_v311_00.go
@@ -283,11 +283,8 @@ func manageOpenShiftAPIServerConfigMap_v311_00_to_latest(kubeClient kubernetes.I
 	// we can embed input hashes on our main configmap to drive rollouts when they change.
 	inputHashes, err := resourcehash.MultipleObjectHashStringMapForObjectReferences(
 		kubeClient,
-		resourcehash.NewObjectRef().ForConfigMap().InNamespace(operatorclient.TargetNamespace).Named("aggregator-client-ca"),
-		resourcehash.NewObjectRef().ForConfigMap().InNamespace(operatorclient.TargetNamespace).Named("client-ca"),
 		resourcehash.NewObjectRef().ForSecret().InNamespace(operatorclient.TargetNamespace).Named("etcd-client"),
 		resourcehash.NewObjectRef().ForConfigMap().InNamespace(operatorclient.TargetNamespace).Named("etcd-serving-ca"),
-		resourcehash.NewObjectRef().ForSecret().InNamespace(operatorclient.TargetNamespace).Named("serving-cert"),
 	)
 	if err != nil {
 		return nil, false, err


### PR DESCRIPTION
Since https://github.com/openshift/origin/pull/22229 merged, we don't have to reload to get certs.

/hold

holding until I complete testing locally.