### PR TITLE
update service-ca controller namespace

### DIFF
--- a/pkg/cmd/resourcegraph/resourcegraph.go
+++ b/pkg/cmd/resourcegraph/resourcegraph.go
@@ -105,7 +105,7 @@ func Resources() resourcegraph.Resources {
 		Add(ret)
 
 	// serving cert
-	serviceCAController := resourcegraph.NewResource(resourcegraph.NewCoordinates("apps", "deployments", "openshift-service-cert-signer", "service-serving-cert-signer")).
+	serviceCAController := resourcegraph.NewResource(resourcegraph.NewCoordinates("apps", "deployments", "openshift-service-ca", "service-serving-cert-signer")).
 		From(serviceCAOperator).
 		Add(ret)
 	servingCert := resourcegraph.NewConfigMap(operatorclient.TargetNamespace, "serving-cert").


### PR DESCRIPTION
We've moved to the new namespace with openshift/service-ca-operator#29
@openshift/sig-auth @deads2k