### PR TITLE
workload: set conditions when kube apiserver is missing

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -110,6 +110,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 		configClient.ConfigV1(),
 		kubeClient,
 		apiregistrationv1Client.ApiregistrationV1(),
+		operatorClient,
 		ctx.EventRecorder,
 	)
 	finalizerController := NewFinalizerController(

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -101,6 +101,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 		os.Getenv("IMAGE"),
 		versionRecorder,
 		operatorConfigInformers.Operator().V1().OpenShiftAPIServers(),
+		operatorConfigInformers.Operator().V1().KubeAPIServers(),
 		kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace),
 		kubeInformersForNamespaces.InformersFor(operatorclient.EtcdNamespaceName),
 		kubeInformersForNamespaces.InformersFor(operatorclient.GlobalUserSpecifiedConfigNamespace),


### PR DESCRIPTION
Set the condition properly when the pre-requirements are missing. This allow us to debug a case when the workload controller wedge and never create the namespace.

The second commit will add event handlers to kube apiserver informer for faster requeue when the kube apiserver config is available.

/cc @sttts 
/cc @deads2k 