### PR TITLE
Increase minimal-shutdown-duration to 35s to cope with slowly converging SDN

### DIFF
--- a/bindata/v3.11.0/openshift-apiserver/defaultconfig.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/defaultconfig.yaml
@@ -45,4 +45,4 @@ auditConfig:
           - "RequestReceived"
 apiServerArguments:
   minimal-shutdown-duration:
-  - 3s # give SDN some time to converge
+  - 35s # give SDN some time to converge: 30s for iptable lock contention, 5s for the second try.

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -150,7 +150,7 @@ auditConfig:
           - "RequestReceived"
 apiServerArguments:
   minimal-shutdown-duration:
-  - 3s # give SDN some time to converge`)
+  - 35s # give SDN some time to converge: 30s for iptable lock contention, 5s for the second try.`)
 
 func v3110OpenshiftApiserverDefaultconfigYamlBytes() ([]byte, error) {
 	return _v3110OpenshiftApiserverDefaultconfigYaml, nil


### PR DESCRIPTION
We still see that endpoints disappear right away on deletion, but requests hit the API server.