### PR TITLE
Add node-selector annotation to namespace

### DIFF
--- a/bindata/v3.11.0/openshift-apiserver/ns.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/ns.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    openshift.io/node-selector: ""
   name: openshift-apiserver
   labels:
     openshift.io/run-level: "1"

--- a/manifests/0000_61_openshift-apiserver-operator_00_namespace.yaml
+++ b/manifests/0000_61_openshift-apiserver-operator_00_namespace.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    openshift.io/node-selector: ""
   labels:
     openshift.io/run-level: "0"
     openshift.io/cluster-monitoring: "true"

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -300,9 +300,12 @@ func v3110OpenshiftApiserverDsYaml() (*asset, error) {
 var _v3110OpenshiftApiserverNsYaml = []byte(`apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    openshift.io/node-selector: ""
   name: openshift-apiserver
   labels:
-    openshift.io/run-level: "1"`)
+    openshift.io/run-level: "1"
+`)
 
 func v3110OpenshiftApiserverNsYamlBytes() ([]byte, error) {
 	return _v3110OpenshiftApiserverNsYaml, nil


### PR DESCRIPTION
**Why this change?**
When https://github.com/openshift/cluster-kube-apiserver-operator/pull/394 merges, all the pods running openshift cluster will have a [defaultNodeSelector](https://docs.openshift.com/container-platform/3.11/admin_guide/managing_projects.html#setting-the-cluster-wide-default-node-selector) if it has been set by cluster-admin including pods running in `openshift-*` namespace. The main advantage of having that feature is in a multi-tenant environment, any new project created can be steered towards compute nodes(non-master nodes).

**What should I do?**
If you think, the pods in your namespace shouldn't have defaultNodeSelector set, please review this PR. If not feel free to close this. The annotation added as part of this PR lets all the pods created within your project to not have the defaultNodeSelector set.


/cc @deads2k @sjenning 
