### PR TITLE
manifests: bump loglevel of operator to normal

### DIFF
--- a/manifests/0000_30_openshift-apiserver-operator_07_deployment.yaml
+++ b/manifests/0000_30_openshift-apiserver-operator_07_deployment.yaml
@@ -31,7 +31,6 @@ spec:
         command: ["cluster-openshift-apiserver-operator", "operator"]
         args:
         - "--config=/var/run/configmaps/config/config.yaml"
-        - "-v=2"
         resources:
           requests:
             memory: 50Mi


### PR DESCRIPTION
We don't need this flag, the loglevel controller manage the log level of operator.