### PR TITLE
Update library-go

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 312b9487cbe0033002ab12280ba260b24698ae7596165589c9efe16bcb19807e
-updated: 2019-04-24T09:32:24.49961991-04:00
+updated: 2019-05-03T14:51:43.155347+02:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -232,7 +232,7 @@ imports:
 - name: github.com/NYTimes/gziphandler
   version: 56545f4a5d46df9a6648819d1664c3a03a13ffdb
 - name: github.com/openshift/api
-  version: adc6b876336b0932967eacf865a544de4e19e605
+  version: 168fd4e3c55217ad0042c4ee1ec79e9ce40d5c21
   subpackages:
   - apps
   - apps/v1
@@ -301,7 +301,7 @@ imports:
   - operator/informers/externalversions/operator/v1
   - operator/listers/operator/v1
 - name: github.com/openshift/library-go
-  version: 154bc7b4c75229c3554688c82eedc0efa5267b25
+  version: 30efb8b70b661872bd0fd9de4ae37f61815bf161
   subpackages:
   - cmd/crd-schema-gen/generator
   - pkg/assets
@@ -895,7 +895,7 @@ imports:
   - pkg/util
   - pkg/util/proto
 - name: sigs.k8s.io/controller-tools
-  version: 61258e1c31f7a84247fd608c0bda7274a50c2d67
+  version: 72ae52c08b9dd626cfb64ebef0fbf40ce667939b
   repo: https://github.com/openshift/kubernetes-sigs-controller-tools
   subpackages:
   - pkg/crd/generator

--- a/pkg/operator/workloadcontroller/workload_controller_openshiftapiserver_v311_00.go
+++ b/pkg/operator/workloadcontroller/workload_controller_openshiftapiserver_v311_00.go
@@ -100,7 +100,7 @@ func syncOpenShiftAPIServer_v311_00_to_latest(c OpenShiftAPIServerOperator, orig
 	// something else, we don't stomp their apiservices until ours have a reasonable chance at working.
 	var actualAPIServices []*apiregistrationv1.APIService
 	if actualDaemonSet != nil && actualDaemonSet.Status.NumberAvailable > 0 {
-		actualAPIServices, err = manageAPIServices_v311_00_to_latest(c.apiregistrationv1Client)
+		actualAPIServices, err = manageAPIServices_v311_00_to_latest(c.apiregistrationv1Client, c.eventRecorder)
 		if err != nil {
 			errors = append(errors, fmt.Errorf("%q: %v", "apiservices", err))
 		}
@@ -329,7 +329,7 @@ func manageOpenShiftAPIServerDaemonSet_v311_00_to_latest(client appsclientv1.Dae
 	return resourceapply.ApplyDaemonSet(client, recorder, required, resourcemerge.ExpectedDaemonSetGeneration(required, generationStatus), forceRollingUpdate)
 }
 
-func manageAPIServices_v311_00_to_latest(client apiregistrationv1client.APIServicesGetter) ([]*apiregistrationv1.APIService, error) {
+func manageAPIServices_v311_00_to_latest(client apiregistrationv1client.APIServicesGetter, recorder events.Recorder) ([]*apiregistrationv1.APIService, error) {
 	var apiServices []*apiregistrationv1.APIService
 	for _, apiServiceGroupVersion := range apiServiceGroupVersions {
 		obj := &apiregistrationv1.APIService{
@@ -351,7 +351,7 @@ func manageAPIServices_v311_00_to_latest(client apiregistrationv1client.APIServi
 			},
 		}
 
-		apiService, _, err := resourceapply.ApplyAPIService(client, obj)
+		apiService, _, err := resourceapply.ApplyAPIService(client, recorder, obj)
 		if err != nil {
 			return nil, err
 		}

--- a/vendor/github.com/openshift/api/operator/v1/types_network.go
+++ b/vendor/github.com/openshift/api/operator/v1/types_network.go
@@ -108,6 +108,10 @@ type AdditionalNetworkDefinition struct {
 	// This must be unique.
 	Name string `json:"name"`
 
+	// namespace is the namespace of the network. This will be populated in the resulting CRD
+	// If not given the network will be created in the default namespace.
+	Namespace string `json:"namespace,omitempty"`
+
 	// rawCNIConfig is the raw CNI configuration json to create in the
 	// NetworkAttachmentDefinition CRD
 	RawCNIConfig string `json:"rawCNIConfig"`

--- a/vendor/github.com/openshift/api/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/vendor/github.com/openshift/api/operator/v1/zz_generated.swagger_doc_generated.go
@@ -293,6 +293,7 @@ var map_AdditionalNetworkDefinition = map[string]string{
 	"":             "AdditionalNetworkDefinition configures an extra network that is available but not created by default. Instead, pods must request them by name. type must be specified, along with exactly one \"Config\" that matches the type.",
 	"type":         "type is the type of network The only supported value is NetworkTypeRaw",
 	"name":         "name is the name of the network. This will be populated in the resulting CRD This must be unique.",
+	"namespace":    "namespace is the namespace of the network. This will be populated in the resulting CRD If not given the network will be created in the default namespace.",
 	"rawCNIConfig": "rawCNIConfig is the raw CNI configuration json to create in the NetworkAttachmentDefinition CRD",
 }
 

--- a/vendor/github.com/openshift/api/security/v1/generated.proto
+++ b/vendor/github.com/openshift/api/security/v1/generated.proto
@@ -189,6 +189,7 @@ message SecurityContextConstraints {
   // for multiple SCCs are equal they will be sorted from most restrictive to
   // least restrictive. If both priorities and restrictions are equal the
   // SCCs will be sorted by name.
+  // +nullable
   optional int32 priority = 2;
 
   // AllowPrivilegedContainer determines if a container can request to be run as privileged.
@@ -197,16 +198,19 @@ message SecurityContextConstraints {
   // DefaultAddCapabilities is the default set of capabilities that will be added to the container
   // unless the pod spec specifically drops the capability.  You may not list a capabiility in both
   // DefaultAddCapabilities and RequiredDropCapabilities.
+  // +nullable
   repeated string defaultAddCapabilities = 4;
 
   // RequiredDropCapabilities are the capabilities that will be dropped from the container.  These
   // are required to be dropped and cannot be added.
+  // +nullable
   repeated string requiredDropCapabilities = 5;
 
   // AllowedCapabilities is a list of capabilities that can be requested to add to the container.
   // Capabilities in this field maybe added at the pod author's discretion.
   // You must not list a capability in both AllowedCapabilities and RequiredDropCapabilities.
   // To allow all capabilities you may use '*'.
+  // +nullable
   repeated string allowedCapabilities = 6;
 
   // AllowHostDirVolumePlugin determines if the policy allow containers to use the HostDir volume plugin
@@ -216,6 +220,7 @@ message SecurityContextConstraints {
   // Volumes is a white list of allowed volume plugins.  FSType corresponds directly with the field names
   // of a VolumeSource (azureFile, configMap, emptyDir).  To allow all volumes you may use "*".
   // To allow no volumes, set to ["none"].
+  // +nullable
   repeated string volumes = 8;
 
   // AllowedFlexVolumes is a whitelist of allowed Flexvolumes.  Empty or nil indicates that all

--- a/vendor/github.com/openshift/api/security/v1/types.go
+++ b/vendor/github.com/openshift/api/security/v1/types.go
@@ -32,6 +32,7 @@ type SecurityContextConstraints struct {
 	// for multiple SCCs are equal they will be sorted from most restrictive to
 	// least restrictive. If both priorities and restrictions are equal the
 	// SCCs will be sorted by name.
+	// +nullable
 	Priority *int32 `json:"priority" protobuf:"varint,2,opt,name=priority"`
 
 	// AllowPrivilegedContainer determines if a container can request to be run as privileged.
@@ -39,14 +40,17 @@ type SecurityContextConstraints struct {
 	// DefaultAddCapabilities is the default set of capabilities that will be added to the container
 	// unless the pod spec specifically drops the capability.  You may not list a capabiility in both
 	// DefaultAddCapabilities and RequiredDropCapabilities.
+	// +nullable
 	DefaultAddCapabilities []corev1.Capability `json:"defaultAddCapabilities" protobuf:"bytes,4,rep,name=defaultAddCapabilities,casttype=Capability"`
 	// RequiredDropCapabilities are the capabilities that will be dropped from the container.  These
 	// are required to be dropped and cannot be added.
+	// +nullable
 	RequiredDropCapabilities []corev1.Capability `json:"requiredDropCapabilities" protobuf:"bytes,5,rep,name=requiredDropCapabilities,casttype=Capability"`
 	// AllowedCapabilities is a list of capabilities that can be requested to add to the container.
 	// Capabilities in this field maybe added at the pod author's discretion.
 	// You must not list a capability in both AllowedCapabilities and RequiredDropCapabilities.
 	// To allow all capabilities you may use '*'.
+	// +nullable
 	AllowedCapabilities []corev1.Capability `json:"allowedCapabilities" protobuf:"bytes,6,rep,name=allowedCapabilities,casttype=Capability"`
 	// AllowHostDirVolumePlugin determines if the policy allow containers to use the HostDir volume plugin
 	// +k8s:conversion-gen=false
@@ -54,6 +58,7 @@ type SecurityContextConstraints struct {
 	// Volumes is a white list of allowed volume plugins.  FSType corresponds directly with the field names
 	// of a VolumeSource (azureFile, configMap, emptyDir).  To allow all volumes you may use "*".
 	// To allow no volumes, set to ["none"].
+	// +nullable
 	Volumes []FSType `json:"volumes" protobuf:"bytes,8,rep,name=volumes,casttype=FSType"`
 	// AllowedFlexVolumes is a whitelist of allowed Flexvolumes.  Empty or nil indicates that all
 	// Flexvolumes may be used.  This parameter is effective only when the usage of the Flexvolumes

--- a/vendor/github.com/openshift/library-go/pkg/controller/controllercmd/cmd.go
+++ b/vendor/github.com/openshift/library-go/pkg/controller/controllercmd/cmd.go
@@ -11,15 +11,17 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"k8s.io/klog"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/util/logs"
+	"k8s.io/klog"
 
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
+
 	"github.com/openshift/library-go/pkg/config/configdefaults"
 	"github.com/openshift/library-go/pkg/crypto"
 	"github.com/openshift/library-go/pkg/serviceability"
@@ -51,22 +53,42 @@ func NewControllerCommandConfig(componentName string, version version.Info, star
 
 // NewCommand returns a new command that a caller must set the Use and Descriptions on.  It wires default log, profiling,
 // leader election and other "normal" behaviors.
+// Deprecated: Use the NewCommandWithContext instead, this is here to be less disturbing for existing usages.
 func (c *ControllerCommandConfig) NewCommand() *cobra.Command {
+	return c.NewCommandWithContext(context.TODO())
+
+}
+
+// NewCommandWithContext returns a new command that a caller must set the Use and Descriptions on.  It wires default log, profiling,
+// leader election and other "normal" behaviors.
+// The context passed will be passed down to controller loops and observers and cancelled on SIGTERM and SIGINT signals.
+func (c *ControllerCommandConfig) NewCommandWithContext(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Run: func(cmd *cobra.Command, args []string) {
 			// boiler plate for the "normal" command
 			rand.Seed(time.Now().UTC().UnixNano())
 			logs.InitLogs()
+
+			// handle SIGTERM and SIGINT by cancelling the context.
+			shutdownCtx, cancel := context.WithCancel(ctx)
+			shutdownHandler := server.SetupSignalHandler()
+			go func() {
+				defer cancel()
+				<-shutdownHandler
+				klog.Infof("Received SIGTERM or SIGINT signal, shutting down controller.")
+			}()
+
 			defer logs.FlushLogs()
 			defer serviceability.BehaviorOnPanic(os.Getenv("OPENSHIFT_ON_PANIC"), c.version)()
 			defer serviceability.Profile(os.Getenv("OPENSHIFT_PROFILE")).Stop()
+
 			serviceability.StartProfiler()
 
 			if err := c.basicFlags.Validate(); err != nil {
 				klog.Fatal(err)
 			}
 
-			if err := c.StartController(context.Background()); err != nil {
+			if err := c.StartController(shutdownCtx); err != nil {
 				klog.Fatal(err)
 			}
 		},

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/cloudprovider/observe_cloudprovider.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/cloudprovider/observe_cloudprovider.go
@@ -6,6 +6,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/library-go/pkg/operator/configobserver"
@@ -92,8 +93,10 @@ func (c *cloudProviderObserver) ObserveCloudProviderNames(genericListers configo
 		Namespace: sourceCloudConfigNamespace,
 		Name:      sourceCloudConfigMap,
 	}
-	// we set cloudprovider configmap values only for vsphere.
-	if cloudProvider != "vsphere" {
+
+	// we set cloudprovider configmap values only for some cloud providers.
+	validCloudProviders := sets.NewString("azure", "vsphere")
+	if !validCloudProviders.Has(cloudProvider) {
 		sourceCloudConfigMap = ""
 	}
 
@@ -143,6 +146,7 @@ func getPlatformName(platformType configv1.PlatformType, recorder events.Recorde
 		cloudProvider = "azure"
 	case configv1.VSpherePlatformType:
 		cloudProvider = "vsphere"
+	case configv1.BareMetalPlatformType:
 	case configv1.LibvirtPlatformType:
 	case configv1.OpenStackPlatformType:
 		// TODO(flaper87): Enable this once we've figured out a way to write the cloud provider config in the master nodes

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/cloudprovider/observe_cloudprovider_test.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/cloudprovider/observe_cloudprovider_test.go
@@ -56,6 +56,9 @@ func TestObserveCloudProviderNames(t *testing.T) {
 		expected:           "azure",
 		cloudProviderCount: 1,
 	}, {
+		platform:           configv1.BareMetalPlatformType,
+		cloudProviderCount: 0,
+	}, {
 		platform:           configv1.LibvirtPlatformType,
 		cloudProviderCount: 0,
 	}, {

--- a/vendor/github.com/openshift/library-go/pkg/operator/events/recorder_in_memory.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/events/recorder_in_memory.go
@@ -38,7 +38,10 @@ func (r *inMemoryEventRecorder) ComponentName() string {
 }
 
 func (r *inMemoryEventRecorder) ForComponent(component string) Recorder {
-	return &inMemoryEventRecorder{events: []*corev1.Event{}, source: component}
+	r.Lock()
+	defer r.Unlock()
+	r.source = component
+	return r
 }
 
 func (r *inMemoryEventRecorder) WithComponentSuffix(suffix string) Recorder {

--- a/vendor/github.com/openshift/library-go/pkg/operator/loglevel/logging_controller_test.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/loglevel/logging_controller_test.go
@@ -1,0 +1,68 @@
+package loglevel
+
+import (
+	"testing"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+func TestClusterOperatorLoggingController(t *testing.T) {
+	if err := SetVerbosityValue(operatorv1.Normal); err != nil {
+		t.Fatal(err)
+	}
+
+	operatorSpec := &operatorv1.OperatorSpec{
+		ManagementState: operatorv1.Managed,
+	}
+
+	fakeStaticPodOperatorClient := v1helpers.NewFakeOperatorClient(
+		operatorSpec,
+		&operatorv1.OperatorStatus{},
+		nil,
+	)
+
+	recorder := events.NewInMemoryRecorder("")
+
+	controller := NewClusterOperatorLoggingController(fakeStaticPodOperatorClient, recorder)
+
+	// no-op, desired == current
+	// When OperatorLogLevel is "" we assume the loglevel is Normal.
+	if err := controller.sync(); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(recorder.Events()) > 0 {
+		t.Fatalf("expected zero events, got %d", len(recorder.Events()))
+	}
+
+	// change the log level to trace should 1 emit event
+	operatorSpec.OperatorLogLevel = operatorv1.Trace
+	if err := controller.sync(); err != nil {
+		t.Fatal(err)
+	}
+
+	if operatorEvents := recorder.Events(); len(operatorEvents) == 1 {
+		expectedEventMessage := `Operator log level changed from "Normal" to "Trace"`
+		if message := operatorEvents[0].Message; message != expectedEventMessage {
+			t.Fatalf("expected event message %q, got %q", expectedEventMessage, message)
+		}
+	} else {
+		t.Fatalf("expected 1 event, got %d", len(operatorEvents))
+	}
+
+	// next sync should not produce any extra event
+	if err := controller.sync(); err != nil {
+		t.Fatal(err)
+	}
+
+	if operatorEvents := recorder.Events(); len(operatorEvents) != 1 {
+		t.Fatalf("expected 1 event recorded, got %d", len(operatorEvents))
+	}
+
+	if current := CurrentLogLevel(); current != operatorv1.Trace {
+		t.Fatalf("expected log level 'Trace', got %v", current)
+	}
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/loglevel/util.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/loglevel/util.go
@@ -1,7 +1,15 @@
 package loglevel
 
-import operatorv1 "github.com/openshift/api/operator/v1"
+import (
+	"flag"
+	"fmt"
 
+	"k8s.io/klog"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+)
+
+// LogLevelToKlog transforms operator log level to a klog numeric verbosity level.
 func LogLevelToKlog(logLevel operatorv1.LogLevel) int {
 	switch logLevel {
 	case operatorv1.Normal:
@@ -15,4 +23,67 @@ func LogLevelToKlog(logLevel operatorv1.LogLevel) int {
 	default:
 		return 2
 	}
+}
+
+// CurrentLogLevel attempts to guess the current log level that is used by klog.
+// We can use flags here as well, but this is less ugly ano more programmatically correct than flags.
+func CurrentLogLevel() operatorv1.LogLevel {
+	switch {
+	case klog.V(8) == true:
+		return operatorv1.TraceAll
+	case klog.V(6) == true:
+		return operatorv1.Trace
+	case klog.V(4) == true:
+		return operatorv1.Debug
+	case klog.V(2) == true:
+		return operatorv1.Normal
+	default:
+		return operatorv1.Normal
+	}
+}
+
+// SetVerbosityValue is a nasty hack and attempt to manipulate the global flags as klog does not expose
+// a way to dynamically change the loglevel in runtime.
+func SetVerbosityValue(logLevel operatorv1.LogLevel) error {
+	if logLevel == CurrentLogLevel() {
+		return nil
+	}
+
+	var level *klog.Level
+
+	// Convert operator loglevel to klog numeric string
+	desiredLevelValue := fmt.Sprintf("%d", LogLevelToKlog(logLevel))
+
+	// First, if the '-v' was specified in command line, attempt to acquire the level pointer from it.
+	if f := flag.CommandLine.Lookup("v"); f != nil {
+		if flagValue, ok := f.Value.(*klog.Level); ok {
+			level = flagValue
+		}
+	}
+
+	// Second, if the '-v' was not set but is still present in flags defined for the command, attempt to acquire it
+	// by visiting all flags.
+	if level == nil {
+		flag.VisitAll(func(f *flag.Flag) {
+			if level != nil {
+				return
+			}
+			if levelFlag, ok := f.Value.(*klog.Level); ok {
+				level = levelFlag
+			}
+		})
+	}
+
+	if level != nil {
+		return level.Set(desiredLevelValue)
+	}
+
+	// Third, if modifying the flag value (which is recommended by klog) fails, then fallback to modifying
+	// the internal state of klog using the empty new level.
+	var newLevel klog.Level
+	if err := newLevel.Set(desiredLevelValue); err != nil {
+		return fmt.Errorf("failed set klog.logging.verbosity %s: %v", desiredLevelValue, err)
+	}
+
+	return nil
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/certsyncpod/certsync_cmd.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/certsyncpod/certsync_cmd.go
@@ -49,7 +49,7 @@ func NewCertSyncControllerCommand(configmaps, secrets []revision.RevisionResourc
 	}
 
 	cmd.Flags().StringVar(&o.DestinationDir, "destination-dir", o.DestinationDir, "Directory to write to")
-	cmd.Flags().StringVarP(&o.Namespace, "namespace", "n", o.Namespace, "Namespace to read from")
+	cmd.Flags().StringVarP(&o.Namespace, "namespace", "n", o.Namespace, "Namespace to read from (default to 'POD_NAMESPACE' environment variable)")
 	cmd.Flags().StringVar(&o.KubeConfigFile, "kubeconfig", o.KubeConfigFile, "Location of the master configuration file to run from.")
 
 	return cmd
@@ -102,6 +102,10 @@ func (o *CertSyncControllerOptions) Complete() error {
 	kubeConfig, err := client.GetKubeConfigOrInClusterConfig(o.KubeConfigFile, nil)
 	if err != nil {
 		return err
+	}
+
+	if len(o.Namespace) == 0 && len(os.Getenv("POD_NAMESPACE")) > 0 {
+		o.Namespace = os.Getenv("POD_NAMESPACE")
 	}
 
 	protoKubeConfig := rest.CopyConfig(kubeConfig)

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -10,18 +10,20 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
-	"k8s.io/klog"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 
@@ -87,16 +89,16 @@ type InstallerController struct {
 // InstallerPodMutationFunc is a function that has a chance at changing the installer pod before it is created
 type InstallerPodMutationFunc func(pod *corev1.Pod, nodeName string, operatorSpec *operatorv1.StaticPodOperatorSpec, revision int32) error
 
-func (o *InstallerController) WithInstallerPodMutationFn(installerPodMutationFn InstallerPodMutationFunc) *InstallerController {
-	o.installerPodMutationFns = append(o.installerPodMutationFns, installerPodMutationFn)
-	return o
+func (c *InstallerController) WithInstallerPodMutationFn(installerPodMutationFn InstallerPodMutationFunc) *InstallerController {
+	c.installerPodMutationFns = append(c.installerPodMutationFns, installerPodMutationFn)
+	return c
 }
 
-func (o *InstallerController) WithCerts(certDir string, certConfigMaps, certSecrets []revision.RevisionResource) *InstallerController {
-	o.certDir = certDir
-	o.certConfigMaps = certConfigMaps
-	o.certSecrets = certSecrets
-	return o
+func (c *InstallerController) WithCerts(certDir string, certConfigMaps, certSecrets []revision.RevisionResource) *InstallerController {
+	c.certDir = certDir
+	c.certConfigMaps = certConfigMaps
+	c.certSecrets = certSecrets
+	return c
 }
 
 // staticPodState is the status of a static pod that has been installed to a node.
@@ -196,14 +198,14 @@ func nodeToStartRevisionWith(getStaticPodState func(nodeName string) (state stat
 	oldestNotReadyRevision := math.MaxInt32
 	for i := range nodes {
 		currNodeState := &nodes[i]
-		state, revision, _, err := getStaticPodState(currNodeState.NodeName)
+		state, currentRevision, _, err := getStaticPodState(currNodeState.NodeName)
 		if err != nil && apierrors.IsNotFound(err) {
 			return i, nil
 		}
 		if err != nil {
 			return 0, err
 		}
-		revisionNum, err := strconv.Atoi(revision)
+		revisionNum, err := strconv.Atoi(currentRevision)
 		if err != nil {
 			return i, nil
 		}
@@ -221,11 +223,11 @@ func nodeToStartRevisionWith(getStaticPodState func(nodeName string) (state stat
 	oldestPodRevision := math.MaxInt32
 	for i := range nodes {
 		currNodeState := &nodes[i]
-		_, revision, _, err := getStaticPodState(currNodeState.NodeName)
+		_, currentRevision, _, err := getStaticPodState(currNodeState.NodeName)
 		if err != nil {
 			return 0, err
 		}
-		revisionNum, err := strconv.Atoi(revision)
+		revisionNum, err := strconv.Atoi(currentRevision)
 		if err != nil {
 			return i, nil
 		}
@@ -297,7 +299,7 @@ func (c *InstallerController) manageInstallationPods(operatorSpec *operatorv1.St
 			}
 
 			pendingNewRevision := operatorStatus.LatestAvailableRevision > currNodeState.TargetRevision
-			newCurrNodeState, oom, err := c.newNodeStateForInstallInProgress(currNodeState, pendingNewRevision)
+			newCurrNodeState, installerPodFailed, err := c.newNodeStateForInstallInProgress(currNodeState, pendingNewRevision)
 			if err != nil {
 				return true, err
 			}
@@ -320,12 +322,12 @@ func (c *InstallerController) manageInstallationPods(operatorSpec *operatorv1.St
 			} else {
 				klog.V(2).Infof("%q is in transition to %d, but has not made progress", currNodeState.NodeName, currNodeState.TargetRevision)
 			}
-			if !oom {
+
+			// We want to retry the installer pod by deleting and then rekicking. Also we don't set LastFailedRevision.
+			if !installerPodFailed {
 				break
 			}
-
-			// OOM is special. We want to retry the installer pod by falling through here. Also we don't set LastFailedRevision.
-			klog.V(2).Infof("Retrying %q for revision %d because it was OOM killed", currNodeState.NodeName, currNodeState.TargetRevision)
+			klog.Infof("Retrying %q for revision %d because it failed", currNodeState.NodeName, currNodeState.TargetRevision)
 			installerPodName := getInstallerPodName(currNodeState.TargetRevision, currNodeState.NodeName)
 			if err := c.podsGetter.Pods(c.targetNamespace).Delete(installerPodName, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 				return true, err
@@ -422,19 +424,16 @@ func setAvailableProgressingNodeInstallerFailingConditions(newStatus *operatorv1
 	failingCount := map[int32]int{}
 	failing := map[int32][]string{}
 	for _, currNodeStatus := range newStatus.NodeStatuses {
+		counts[currNodeStatus.CurrentRevision] = counts[currNodeStatus.CurrentRevision] + 1
 		if currNodeStatus.CurrentRevision != 0 {
 			numAvailable++
 		}
 
 		// keep track of failures so that we can report failing status
 		if currNodeStatus.LastFailedRevision != 0 {
-			existing := failingCount[currNodeStatus.CurrentRevision]
-			failingCount[currNodeStatus.CurrentRevision] = existing + 1
+			failingCount[currNodeStatus.LastFailedRevision] = failingCount[currNodeStatus.LastFailedRevision] + 1
 			failing[currNodeStatus.LastFailedRevision] = append(failing[currNodeStatus.LastFailedRevision], currNodeStatus.LastFailedRevisionErrors...)
 		}
-
-		existing := counts[currNodeStatus.CurrentRevision]
-		counts[currNodeStatus.CurrentRevision] = existing + 1
 
 		if newStatus.LatestAvailableRevision == currNodeStatus.CurrentRevision {
 			numAtLatestRevision += 1
@@ -444,9 +443,13 @@ func setAvailableProgressingNodeInstallerFailingConditions(newStatus *operatorv1
 	}
 
 	revisionStrings := []string{}
-	for _, revision := range Int32KeySet(counts).List() {
-		count := counts[revision]
-		revisionStrings = append(revisionStrings, fmt.Sprintf("%d nodes are at revision %d", count, revision))
+	for _, currentRevision := range Int32KeySet(counts).List() {
+		count := counts[currentRevision]
+		revisionStrings = append(revisionStrings, fmt.Sprintf("%d nodes are at revision %d", count, currentRevision))
+	}
+	// if we are progressing and no nodes have achieved that level, we should indicate
+	if numProgressing > 0 && counts[newStatus.LatestAvailableRevision] == 0 {
+		revisionStrings = append(revisionStrings, fmt.Sprintf("%d nodes have achieved new revision %d", 0, newStatus.LatestAvailableRevision))
 	}
 	revisionDescription := strings.Join(revisionStrings, "; ")
 
@@ -485,10 +488,6 @@ func setAvailableProgressingNodeInstallerFailingConditions(newStatus *operatorv1
 		failingStrings := []string{}
 		for _, failingRevision := range Int32KeySet(failing).List() {
 			errorStrings := failing[failingRevision]
-			// Do not report failing for nodes that are actually not failing.
-			if failingCount[failingRevision] == 0 {
-				continue
-			}
 			failingStrings = append(failingStrings, fmt.Sprintf("%d nodes are failing on revision %d:\n%v", failingCount[failingRevision], failingRevision, strings.Join(errorStrings, "\n")))
 		}
 		failingDescription := strings.Join(failingStrings, "; ")
@@ -510,7 +509,7 @@ func setAvailableProgressingNodeInstallerFailingConditions(newStatus *operatorv1
 }
 
 // newNodeStateForInstallInProgress returns the new NodeState, whether it was killed by OOM or an error
-func (c *InstallerController) newNodeStateForInstallInProgress(currNodeState *operatorv1.NodeStatus, newRevisionPending bool) (status *operatorv1.NodeStatus, oom bool, err error) {
+func (c *InstallerController) newNodeStateForInstallInProgress(currNodeState *operatorv1.NodeStatus, newRevisionPending bool) (status *operatorv1.NodeStatus, installerPodFailed bool, err error) {
 	ret := currNodeState.DeepCopy()
 	installerPod, err := c.podsGetter.Pods(c.targetNamespace).Get(getInstallerPodName(currNodeState.TargetRevision, currNodeState.NodeName), metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
@@ -535,12 +534,12 @@ func (c *InstallerController) newNodeStateForInstallInProgress(currNodeState *op
 			break
 		}
 
-		state, revision, failedErrors, err := c.getStaticPodState(currNodeState.NodeName)
+		state, currentRevision, failedErrors, err := c.getStaticPodState(currNodeState.NodeName)
 		if err != nil {
 			return nil, false, err
 		}
 
-		if revision != strconv.Itoa(int(currNodeState.TargetRevision)) {
+		if currentRevision != strconv.Itoa(int(currNodeState.TargetRevision)) {
 			// new updated pod to be launched
 			break
 		}
@@ -563,10 +562,9 @@ func (c *InstallerController) newNodeStateForInstallInProgress(currNodeState *op
 		for _, containerStatus := range installerPod.Status.ContainerStatuses {
 			if containerStatus.State.Terminated != nil && len(containerStatus.State.Terminated.Message) > 0 {
 				errors = append(errors, fmt.Sprintf("%s: %s", containerStatus.Name, containerStatus.State.Terminated.Message))
-				if containerStatus.State.Terminated.Reason == "OOMKilled" {
-					// do not set LastFailedRevision
-					return currNodeState, true, nil
-				}
+				c.eventRecorder.Warningf("InstallerPodFailed", "installer errors: %v", strings.Join(errors, "\n"))
+				// do not set LastFailedRevision
+				return currNodeState, true, nil
 			}
 		}
 	}
@@ -705,43 +703,74 @@ func getInstallerPodImageFromEnv() string {
 	return os.Getenv("OPERATOR_IMAGE")
 }
 
-// ensureCerts makes sure that our certs are ready or it will return an error to trigger a requeue so that we try again
-func (c InstallerController) ensureCerts() error {
-	missing := []string{}
-	for _, cm := range c.certConfigMaps {
-		if cm.Optional {
+func (c InstallerController) ensureSecretRevisionResourcesExists(secrets []revision.RevisionResource, hasRevisionSuffix bool, latestRevisionNumber int32) error {
+	missing := sets.NewString()
+	for _, secret := range secrets {
+		if secret.Optional {
 			continue
 		}
-		_, err := c.configMapsGetter.ConfigMaps(c.targetNamespace).Get(cm.Name, metav1.GetOptions{})
+		name := secret.Name
+		if !hasRevisionSuffix {
+			name = fmt.Sprintf("%s-%d", name, latestRevisionNumber)
+		}
+		_, err := c.secretsGetter.Secrets(c.targetNamespace).Get(name, metav1.GetOptions{})
 		if err == nil {
 			continue
 		}
 		if apierrors.IsNotFound(err) {
-			missing = append(missing, "configmaps/"+cm.Name)
-			continue
+			missing.Insert(name)
 		}
-		return err
 	}
-	for _, s := range c.certSecrets {
-		if s.Optional {
-			continue
-		}
-		_, err := c.secretsGetter.Secrets(c.targetNamespace).Get(s.Name, metav1.GetOptions{})
-		if err == nil {
-			continue
-		}
-		if apierrors.IsNotFound(err) {
-			missing = append(missing, "secrets/"+s.Name)
-			continue
-		}
-		return err
+	if missing.Len() == 0 {
+		return nil
 	}
+	return fmt.Errorf("secrets: %s", strings.Join(missing.List(), ","))
+}
 
-	if len(missing) == 0 {
+func (c InstallerController) ensureConfigMapRevisionResourcesExists(configs []revision.RevisionResource, hasRevisionSuffix bool, latestRevisionNumber int32) error {
+	missing := sets.NewString()
+	for _, config := range configs {
+		if config.Optional {
+			continue
+		}
+		name := config.Name
+		if !hasRevisionSuffix {
+			name = fmt.Sprintf("%s-%d", name, latestRevisionNumber)
+		}
+		_, err := c.configMapsGetter.ConfigMaps(c.targetNamespace).Get(name, metav1.GetOptions{})
+		if err == nil {
+			continue
+		}
+		if apierrors.IsNotFound(err) {
+			missing.Insert(name)
+		}
+	}
+	if missing.Len() == 0 {
+		return nil
+	}
+	return fmt.Errorf("configmaps: %s", strings.Join(missing.List(), ","))
+}
+
+// ensureRequiredResourcesExist makes sure that all non-optional resources are ready or it will return an error to trigger a requeue so that we try again.
+func (c InstallerController) ensureRequiredResourcesExist(revisionNumber int32) error {
+	errs := []error{}
+
+	errs = append(errs, c.ensureConfigMapRevisionResourcesExists(c.certConfigMaps, true, revisionNumber))
+	errs = append(errs, c.ensureConfigMapRevisionResourcesExists(c.configMaps, false, revisionNumber))
+	errs = append(errs, c.ensureSecretRevisionResourcesExists(c.certSecrets, true, revisionNumber))
+	errs = append(errs, c.ensureSecretRevisionResourcesExists(c.secrets, false, revisionNumber))
+
+	aggregatedErr := utilerrors.NewAggregate(errs)
+	if aggregatedErr == nil {
 		return nil
 	}
 
-	return fmt.Errorf("missing: %v", strings.Join(missing, ","))
+	eventMessages := []string{}
+	for _, err := range aggregatedErr.Errors() {
+		eventMessages = append(eventMessages, err.Error())
+	}
+	c.eventRecorder.Warningf("RequiredInstallerResourcesMissing", strings.Join(eventMessages, ", "))
+	return fmt.Errorf("missing required resources: %v", aggregatedErr)
 }
 
 func (c InstallerController) sync() error {
@@ -755,17 +784,19 @@ func (c InstallerController) sync() error {
 		return nil
 	}
 
-	if err := c.ensureCerts(); err != nil {
-		return err
+	err = c.ensureRequiredResourcesExist(originalOperatorStatus.LatestAvailableRevision)
+
+	// Only manage installation pods when all required certs are present.
+	if err == nil {
+		requeue, syncErr := c.manageInstallationPods(operatorSpec, operatorStatus, resourceVersion)
+		if requeue && syncErr == nil {
+			return fmt.Errorf("synthetic requeue request")
+		}
+		err = syncErr
 	}
 
-	requeue, syncErr := c.manageInstallationPods(operatorSpec, operatorStatus, resourceVersion)
-	if requeue && syncErr == nil {
-		return fmt.Errorf("synthetic requeue request")
-	}
-	err = syncErr
-
-	// update failing condition
+	// Update failing condition
+	// If required certs are missing, this will report degraded as we can't create installer pods because of this pre-condition.
 	cond := operatorv1.OperatorCondition{
 		Type:   operatorStatusInstallerControllerDegraded,
 		Status: operatorv1.ConditionFalse,

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/monitoring/monitoring_resource_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/monitoring/monitoring_resource_controller.go
@@ -5,11 +5,9 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/openshift/library-go/pkg/operator/management"
-	"github.com/openshift/library-go/pkg/operator/v1helpers"
-
 	"k8s.io/klog"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
@@ -20,10 +18,13 @@ import (
 	"k8s.io/client-go/util/workqueue"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
+
 	"github.com/openshift/library-go/pkg/assets"
 	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/management"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/staticpod/controller/monitoring/bindata"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
 
 const (
@@ -31,6 +32,8 @@ const (
 	controllerWorkQueueKey                             = "key"
 	manifestDir                                        = "pkg/operator/staticpod/controller/monitoring"
 )
+
+var syntheticRequeueError = fmt.Errorf("synthetic requeue request")
 
 type MonitoringResourceController struct {
 	targetNamespace    string
@@ -119,7 +122,14 @@ func (c MonitoringResourceController) sync() error {
 		errs = append(errs, fmt.Errorf("manifests/service-monitor.yaml: %v", err))
 	} else {
 		_, serviceMonitorErr := resourceapply.ApplyServiceMonitor(c.dynamicClient, c.eventRecorder, serviceMonitorBytes)
-		errs = append(errs, serviceMonitorErr)
+		// This is to handle 'the server could not find the requested resource' which occurs when the CRD is not available
+		// yet (the CRD is provided by prometheus operator). This produce noise and plenty of events.
+		if errors.IsNotFound(serviceMonitorErr) {
+			klog.V(4).Infof("Unable to apply service monitor: %v", err)
+			return syntheticRequeueError
+		} else if serviceMonitorErr != nil {
+			errs = append(errs, serviceMonitorErr)
+		}
 	}
 
 	err = v1helpers.NewMultiLineAggregate(errs)
@@ -179,7 +189,10 @@ func (c *MonitoringResourceController) processNextWorkItem() bool {
 		return true
 	}
 
-	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
+	if err != syntheticRequeueError {
+		utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
+	}
+
 	c.queue.AddRateLimited(dsKey)
 
 	return true

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/staticpodstate/staticpodstate_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/staticpodstate/staticpodstate_controller.go
@@ -135,6 +135,10 @@ func (c *StaticPodStateController) sync() error {
 			c.operandName,
 			status.VersionForOperandFromEnv(),
 		)
+		c.versionRecorder.SetVersion(
+			"operator",
+			status.VersionForOperatorFromEnv(),
+		)
 	}
 
 	// update failing condition

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/installerpod/cmd.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/installerpod/cmd.go
@@ -215,7 +215,7 @@ func (o *InstallOptions) copySecretsAndConfigMaps(ctx context.Context, resourceD
 		for filename, content := range secret.Data {
 			// TODO fix permissions
 			klog.Infof("Writing secret manifest %q ...", path.Join(contentDir, filename))
-			if err := ioutil.WriteFile(path.Join(contentDir, filename), content, 0644); err != nil {
+			if err := ioutil.WriteFile(path.Join(contentDir, filename), content, 0600); err != nil {
 				return err
 			}
 		}

--- a/vendor/github.com/openshift/library-go/pkg/operator/status/version.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/status/version.go
@@ -18,7 +18,8 @@ type versionGetter struct {
 }
 
 const (
-	operandImageVersionEnvVarName = "OPERAND_IMAGE_VERSION"
+	operandImageVersionEnvVarName  = "OPERAND_IMAGE_VERSION"
+	operatorImageVersionEnvVarName = "OPERATOR_IMAGE_VERSION"
 )
 
 func NewVersionGetter() VersionGetter {
@@ -64,6 +65,10 @@ func (v *versionGetter) VersionChangedChannel() <-chan struct{} {
 
 func VersionForOperandFromEnv() string {
 	return os.Getenv(operandImageVersionEnvVarName)
+}
+
+func VersionForOperatorFromEnv() string {
+	return os.Getenv(operatorImageVersionEnvVarName)
 }
 
 func VersionForOperand(namespace, imagePullSpec string, configMapGetter corev1client.ConfigMapsGetter, eventRecorder events.Recorder) string {

--- a/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/helpers.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/helpers.go
@@ -1,20 +1,14 @@
 package v1helpers
 
 import (
-	"fmt"
 	"strings"
 	"time"
 
-	"github.com/ghodss/yaml"
-
 	"k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/util/retry"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -110,33 +104,6 @@ func IsOperatorConditionPresentAndEqual(conditions []operatorv1.OperatorConditio
 	return false
 }
 
-func EnsureOperatorConfigExists(client dynamic.Interface, operatorConfigBytes []byte, gvr schema.GroupVersionResource) {
-	configJson, err := yaml.YAMLToJSON(operatorConfigBytes)
-	if err != nil {
-		panic(err)
-	}
-	operatorConfigObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, configJson)
-	if err != nil {
-		panic(err)
-	}
-
-	requiredOperatorConfig, ok := operatorConfigObj.(*unstructured.Unstructured)
-	if !ok {
-		panic(fmt.Sprintf("unexpected object in %t", operatorConfigObj))
-	}
-
-	_, err = client.Resource(gvr).Get(requiredOperatorConfig.GetName(), metav1.GetOptions{})
-	if errors.IsNotFound(err) {
-		if _, err := client.Resource(gvr).Create(requiredOperatorConfig, metav1.CreateOptions{}); err != nil {
-			panic(err)
-		}
-		return
-	}
-	if err != nil {
-		panic(err)
-	}
-}
-
 // UpdateOperatorSpecFunc is a func that mutates an operator spec.
 type UpdateOperatorSpecFunc func(spec *operatorv1.OperatorSpec) error
 
@@ -198,6 +165,8 @@ func UpdateStatus(client OperatorClient, updateFuncs ...UpdateStatusFunc) (*oper
 		}
 
 		if equality.Semantic.DeepEqual(oldStatus, newStatus) {
+			// We return the newStatus which is a deep copy of oldStatus but with all update funcs applied.
+			updatedOperatorStatus = newStatus
 			return nil
 		}
 

--- a/vendor/sigs.k8s.io/controller-tools/Gopkg.lock
+++ b/vendor/sigs.k8s.io/controller-tools/Gopkg.lock
@@ -192,15 +192,16 @@
   version = "kubernetes-1.13.4"
 
 [[projects]]
-  digest = "1:46e3296eec0a6e864c2ef813ccfdb0b83d144fcc23414d97dd4894e9464cf4d5"
+  branch = "origin-4.1-kubernetes-1.13.4"
+  digest = "1:7e8f9684c9d41430c0a3d34eae8e0141bf38963ad998db1b8b66aa263d116d08"
   name = "k8s.io/apiextensions-apiserver"
   packages = [
     "pkg/apis/apiextensions",
     "pkg/apis/apiextensions/v1beta1",
   ]
   pruneopts = "UT"
-  revision = "d002e88f6236312f0289d9d1deab106751718ff0"
-  version = "kubernetes-1.13.4"
+  revision = "3c74db8dd172051b029f91536c681a1b43694809"
+  source = "github.com/openshift/kubernetes-apiextensions-apiserver"
 
 [[projects]]
   digest = "1:cdadd6ffbd40cc74095fc26f5cf8bb06631adf7a614307b6c6ddf19da29dec05"

--- a/vendor/sigs.k8s.io/controller-tools/Gopkg.toml
+++ b/vendor/sigs.k8s.io/controller-tools/Gopkg.toml
@@ -8,7 +8,8 @@ ignored = [
 
 [[constraint]]
   name="k8s.io/apiextensions-apiserver"
-  version="kubernetes-1.13.4"
+  branch="origin-4.1-kubernetes-1.13.4"
+  source="github.com/openshift/kubernetes-apiextensions-apiserver"
 
 [[constraint]]
   name="k8s.io/apimachinery"


### PR DESCRIPTION
* library-go#386: Specify no cloud provider for the baremetal platform
* library-go#387: Handle TERM and INT signals gracefully in operators
* library-go#390: Only acccept cloud config files for certain providers
* library-go#391: Make installer pods save secrets using 0600
* library-go#385: Default namespace to POD_NAMESPACE env var in certsync pod