### PR TITLE
Bug 1718052: Do not log OAuth tokens in audit logs

### DIFF
--- a/bindata/v3.11.0/openshift-apiserver/defaultconfig.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/defaultconfig.yaml
@@ -30,6 +30,11 @@ auditConfig:
         resources:
           - group: ""
             resources: ["events"]
+      # Don't log oauth tokens as metadata.name is the secret
+      - level: None
+        resources:
+        - group: "oauth.openshift.io"
+          resources: ["oauthaccesstokens", "oauthauthorizetokens"]
       # Don't log authenticated requests to certain non-resource URL paths.
       - level: None
         userGroups: ["system:authenticated", "system:unauthenticated"]

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -134,6 +134,11 @@ auditConfig:
         resources:
           - group: ""
             resources: ["events"]
+      # Don't log oauth tokens as metadata.name is the secret
+      - level: None
+        resources:
+        - group: "oauth.openshift.io"
+          resources: ["oauthaccesstokens", "oauthauthorizetokens"]
       # Don't log authenticated requests to certain non-resource URL paths.
       - level: None
         userGroups: ["system:authenticated", "system:unauthenticated"]


### PR DESCRIPTION
Even the metadata level is not safe as metadata.name is the secret.

Signed-off-by: Monis Khan <mkhan@redhat.com>

@deads2k 