### PR TITLE
fix make images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,15 @@ include $(addprefix ./vendor/github.com/openshift/library-go/alpha-build-machine
 	targets/openshift/images.mk \
 )
 
+IMAGE_REGISTRY :=registry.svc.ci.openshift.org
+
 # This will call a macro called "build-image" which will generate image specific targets based on the parameters:
 # $0 - macro name
-# $1 - target suffix
-# $2 - Dockerfile path
-# $3 - context directory for image build
-# It will generate target "image-$(1)" for builing the image an binding it as a prerequisite to target "images".
-$(call build-image,origin-$(GO_PACKAGE),./Dockerfile,.)
+# $1 - target name
+# $2 - image ref
+# $3 - Dockerfile path
+# $4 - context directory for image build
+$(call build-image,ocp-cluster-openshift-apiserver-operator,$(IMAGE_REGISTRY)/ocp/4.2:cluster-openshift-apiserver-operator,./Dockerfile.rhel7,.)
 
 # This will call a macro called "add-bindata" which will generate bindata specific targets based on the parameters:
 # $0 - macro name


### PR DESCRIPTION
This PR fixes `make images`, it requires `image name` now. 

(`make images` is only used in local development, AFAIK)