### PR TITLE
Bug 1746375: Revert use of watchdog for trusted-ca-bundle

### DIFF
--- a/bindata/v3.11.0/openshift-apiserver/ds.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/ds.yaml
@@ -22,7 +22,6 @@ spec:
     spec:
       serviceAccountName: openshift-apiserver-sa
       priorityClassName: system-node-critical
-      shareProcessNamespace: true
       initContainers:
         - name: fix-audit-permissions
           terminationMessagePolicy: FallbackToLogsOnError
@@ -40,13 +39,6 @@ spec:
         command: ["/bin/bash", "-ec"]
         args:
           - |
-            echo $$$$ > /var/run/watchdog/pid
-            echo -n "Waiting for watchdog..."
-            while [ ! -f /var/run/watchdog/ready ]; do
-              echo -n "."
-              sleep 1
-            done
-            echo
             if [ -s /var/run/configmaps/trusted-ca-bundle/tls-ca-bundle.pem ]; then
               echo "Copying system trust bundle"
               cp -f /var/run/configmaps/trusted-ca-bundle/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
@@ -80,8 +72,6 @@ spec:
           name: serving-cert
         - mountPath: /var/log/openshift-apiserver
           name: audit-dir
-        - mountPath: /var/run/watchdog
-          name: watchdog-dir
         livenessProbe:
           initialDelaySeconds: 30
           httpGet:
@@ -94,39 +84,6 @@ spec:
             scheme: HTTPS
             port: 8443
             path: healthz
-      - name: openshift-apiserver-watchdog
-        command: ["cluster-openshift-apiserver-operator", "file-watcher-watchdog"]
-        args:
-          - --namespace=$(POD_NAMESPACE)
-          - --termination-grace-period=60s
-          - --files=/var/run/configmaps/trusted-ca-bundle/tls-ca-bundle.pem
-          - --pid-file=/var/run/watchdog/pid
-          - --ready-file=/var/run/watchdog/ready
-        securityContext:
-          capabilities:
-            add:
-              - SYS_PTRACE
-        env:
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-        image: ${OPERATOR_IMAGE}
-        imagePullPolicy: IfNotPresent
-        volumeMounts:
-          - mountPath: /etc/pki/ca-trust/extracted/pem/
-            name: trusted-ca-bundle
-          - mountPath: /var/run/watchdog
-            name: watchdog-dir
-        terminationMessagePolicy: FallbackToLogsOnError
-        resources:
-          requests:
-            memory: 50Mi
-            cpu: 10m
       terminationGracePeriodSeconds: 70 # a bit more than the 60 seconds timeout of non-long-running requests
       volumes:
       - name: aggregator-client-ca
@@ -161,8 +118,6 @@ spec:
       - hostPath:
           path: /var/log/openshift-apiserver
         name: audit-dir
-      - emptyDir: {}
-        name: watchdog-dir
       nodeSelector:
         node-role.kubernetes.io/master: ""
       tolerations:

--- a/cmd/cluster-openshift-apiserver-operator/main.go
+++ b/cmd/cluster-openshift-apiserver-operator/main.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/openshift/cluster-openshift-apiserver-operator/pkg/cmd/operator"
 	"github.com/openshift/cluster-openshift-apiserver-operator/pkg/cmd/resourcegraph"
-	"github.com/openshift/library-go/pkg/operator/watchdog"
 )
 
 func main() {
@@ -46,7 +45,6 @@ func NewSSCSCommand() *cobra.Command {
 
 	cmd.AddCommand(operator.NewOperator())
 	cmd.AddCommand(resourcegraph.NewResourceChainCommand())
-	cmd.AddCommand(watchdog.NewFileWatcherWatchdog())
 
 	return cmd
 }

--- a/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
+++ b/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
@@ -50,6 +50,12 @@ func NewResourceSyncController(
 	); err != nil {
 		return nil, nil, err
 	}
+	if err := resourceSyncController.SyncConfigMap(
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "trusted-ca-bundle"},
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: "trusted-ca-bundle"},
+	); err != nil {
+		return nil, nil, err
+	}
 
 	return resourceSyncController, resourcesynccontroller.NewDebugHandler(resourceSyncController), nil
 }

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -200,7 +200,6 @@ spec:
     spec:
       serviceAccountName: openshift-apiserver-sa
       priorityClassName: system-node-critical
-      shareProcessNamespace: true
       initContainers:
         - name: fix-audit-permissions
           terminationMessagePolicy: FallbackToLogsOnError
@@ -218,13 +217,6 @@ spec:
         command: ["/bin/bash", "-ec"]
         args:
           - |
-            echo $$$$ > /var/run/watchdog/pid
-            echo -n "Waiting for watchdog..."
-            while [ ! -f /var/run/watchdog/ready ]; do
-              echo -n "."
-              sleep 1
-            done
-            echo
             if [ -s /var/run/configmaps/trusted-ca-bundle/tls-ca-bundle.pem ]; then
               echo "Copying system trust bundle"
               cp -f /var/run/configmaps/trusted-ca-bundle/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
@@ -258,8 +250,6 @@ spec:
           name: serving-cert
         - mountPath: /var/log/openshift-apiserver
           name: audit-dir
-        - mountPath: /var/run/watchdog
-          name: watchdog-dir
         livenessProbe:
           initialDelaySeconds: 30
           httpGet:
@@ -272,39 +262,6 @@ spec:
             scheme: HTTPS
             port: 8443
             path: healthz
-      - name: openshift-apiserver-watchdog
-        command: ["cluster-openshift-apiserver-operator", "file-watcher-watchdog"]
-        args:
-          - --namespace=$(POD_NAMESPACE)
-          - --termination-grace-period=60s
-          - --files=/var/run/configmaps/trusted-ca-bundle/tls-ca-bundle.pem
-          - --pid-file=/var/run/watchdog/pid
-          - --ready-file=/var/run/watchdog/ready
-        securityContext:
-          capabilities:
-            add:
-              - SYS_PTRACE
-        env:
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-        image: ${OPERATOR_IMAGE}
-        imagePullPolicy: IfNotPresent
-        volumeMounts:
-          - mountPath: /etc/pki/ca-trust/extracted/pem/
-            name: trusted-ca-bundle
-          - mountPath: /var/run/watchdog
-            name: watchdog-dir
-        terminationMessagePolicy: FallbackToLogsOnError
-        resources:
-          requests:
-            memory: 50Mi
-            cpu: 10m
       terminationGracePeriodSeconds: 70 # a bit more than the 60 seconds timeout of non-long-running requests
       volumes:
       - name: aggregator-client-ca
@@ -339,8 +296,6 @@ spec:
       - hostPath:
           path: /var/log/openshift-apiserver
         name: audit-dir
-      - emptyDir: {}
-        name: watchdog-dir
       nodeSelector:
         node-role.kubernetes.io/master: ""
       tolerations:

--- a/pkg/operator/workloadcontroller/workload_controller_openshiftapiserver_v311_00.go
+++ b/pkg/operator/workloadcontroller/workload_controller_openshiftapiserver_v311_00.go
@@ -81,7 +81,6 @@ func syncOpenShiftAPIServer_v311_00_to_latest(c OpenShiftAPIServerOperator, orig
 		reasonsForForcedRollingUpdate = append(reasonsForForcedRollingUpdate, "modified: "+resourceSelectorForCLI(imageImportCAModifiedObject))
 	}
 
-	// we don't need to check for the CM changes, those are handled by the watchdog
 	err = ensureOpenShiftAPIServerTrustedCA_v311_00_to_latest(c.kubeClient.CoreV1(), c.eventRecorder)
 	if err != nil {
 		errors = append(errors, fmt.Errorf("%q: %v", "trusted-ca-bundle", err))

--- a/pkg/operator/workloadcontroller/workload_controller_openshiftapiserver_v311_00.go
+++ b/pkg/operator/workloadcontroller/workload_controller_openshiftapiserver_v311_00.go
@@ -326,6 +326,7 @@ func manageOpenShiftAPIServerConfigMap_v311_00_to_latest(kubeClient kubernetes.I
 		kubeClient,
 		resourcehash.NewObjectRef().ForSecret().InNamespace(operatorclient.TargetNamespace).Named("etcd-client"),
 		resourcehash.NewObjectRef().ForConfigMap().InNamespace(operatorclient.TargetNamespace).Named("etcd-serving-ca"),
+		resourcehash.NewObjectRef().ForConfigMap().InNamespace(operatorclient.TargetNamespace).Named("trusted-ca-bundle"),
 	)
 	if err != nil {
 		return nil, false, err


### PR DESCRIPTION
Instead use operator driven rollout. This is enforced by hashing the the configmap contents and adding that to the deployment (that mechanism preexisted).