### PR TITLE
Bug 1747260: manifests: move trusted-ca into right spot

### DIFF
--- a/manifests/0000_30_openshift-apiserver-operator_03_trusted_ca_cm.yaml
+++ b/manifests/0000_30_openshift-apiserver-operator_03_trusted_ca_cm.yaml
@@ -3,5 +3,7 @@ kind: ConfigMap
 metadata:
   namespace: openshift-apiserver-operator
   name: trusted-ca-bundle
+  annotations:
+    release.openshift.io/create-only: "true"
   labels:
     config.openshift.io/inject-trusted-cabundle: "true"

--- a/manifests/0000_30_openshift-apiserver-operator_03_trusted_ca_cm.yaml
+++ b/manifests/0000_30_openshift-apiserver-operator_03_trusted_ca_cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: openshift-apiserver
+  namespace: openshift-apiserver-operator
   name: trusted-ca-bundle
   labels:
     config.openshift.io/inject-trusted-cabundle: "true"

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -7,7 +7,6 @@
 // bindata/v3.11.0/openshift-apiserver/ns.yaml
 // bindata/v3.11.0/openshift-apiserver/sa.yaml
 // bindata/v3.11.0/openshift-apiserver/svc.yaml
-// bindata/v3.11.0/openshift-apiserver/trusted-ca-cm.yaml
 // DO NOT EDIT!
 
 package v311_00_assets
@@ -398,30 +397,6 @@ func v3110OpenshiftApiserverSvcYaml() (*asset, error) {
 	return a, nil
 }
 
-var _v3110OpenshiftApiserverTrustedCaCmYaml = []byte(`apiVersion: v1
-kind: ConfigMap
-metadata:
-  namespace: openshift-apiserver
-  name: trusted-ca-bundle
-  labels:
-    config.openshift.io/inject-trusted-cabundle: "true"
-`)
-
-func v3110OpenshiftApiserverTrustedCaCmYamlBytes() ([]byte, error) {
-	return _v3110OpenshiftApiserverTrustedCaCmYaml, nil
-}
-
-func v3110OpenshiftApiserverTrustedCaCmYaml() (*asset, error) {
-	bytes, err := v3110OpenshiftApiserverTrustedCaCmYamlBytes()
-	if err != nil {
-		return nil, err
-	}
-
-	info := bindataFileInfo{name: "v3.11.0/openshift-apiserver/trusted-ca-cm.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
-	a := &asset{bytes: bytes, info: info}
-	return a, nil
-}
-
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -481,7 +456,6 @@ var _bindata = map[string]func() (*asset, error){
 	"v3.11.0/openshift-apiserver/ns.yaml":                           v3110OpenshiftApiserverNsYaml,
 	"v3.11.0/openshift-apiserver/sa.yaml":                           v3110OpenshiftApiserverSaYaml,
 	"v3.11.0/openshift-apiserver/svc.yaml":                          v3110OpenshiftApiserverSvcYaml,
-	"v3.11.0/openshift-apiserver/trusted-ca-cm.yaml":                v3110OpenshiftApiserverTrustedCaCmYaml,
 }
 
 // AssetDir returns the file names below a certain
@@ -534,7 +508,6 @@ var _bintree = &bintree{nil, map[string]*bintree{
 			"ns.yaml":                           {v3110OpenshiftApiserverNsYaml, map[string]*bintree{}},
 			"sa.yaml":                           {v3110OpenshiftApiserverSaYaml, map[string]*bintree{}},
 			"svc.yaml":                          {v3110OpenshiftApiserverSvcYaml, map[string]*bintree{}},
-			"trusted-ca-cm.yaml":                {v3110OpenshiftApiserverTrustedCaCmYaml, map[string]*bintree{}},
 		}},
 	}},
 }}


### PR DESCRIPTION
This moves the configmap into right spot (operator namespace). Operator will then copy it.

NOTE: Operator will copy it with the inject label, which means both this operator and networking operator will manage the config map. Since it should always have the right content, I don't see this as a big problem, but it breaks the pattern of "only one controller manage".