### PR TITLE
Bug 1747260: Fix trusted-ca-bundle CM syncing

### DIFF
--- a/manifests/0000_30_openshift-apiserver-operator_03_trusted_ca_cm.yaml
+++ b/manifests/0000_30_openshift-apiserver-operator_03_trusted_ca_cm.yaml
@@ -1,7 +1,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: openshift-apiserver
+  namespace: openshift-apiserver-operator
   name: trusted-ca-bundle
+  annotations:
+    release.openshift.io/create-only: "true"
   labels:
     config.openshift.io/inject-trusted-cabundle: "true"

--- a/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
+++ b/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
@@ -50,12 +50,6 @@ func NewResourceSyncController(
 	); err != nil {
 		return nil, nil, err
 	}
-	if err := resourceSyncController.SyncConfigMap(
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "trusted-ca-bundle"},
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: "trusted-ca-bundle"},
-	); err != nil {
-		return nil, nil, err
-	}
 
 	return resourceSyncController, resourcesynccontroller.NewDebugHandler(resourceSyncController), nil
 }

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -7,7 +7,6 @@
 // bindata/v3.11.0/openshift-apiserver/ns.yaml
 // bindata/v3.11.0/openshift-apiserver/sa.yaml
 // bindata/v3.11.0/openshift-apiserver/svc.yaml
-// bindata/v3.11.0/openshift-apiserver/trusted-ca-cm.yaml
 // DO NOT EDIT!
 
 package v311_00_assets
@@ -398,30 +397,6 @@ func v3110OpenshiftApiserverSvcYaml() (*asset, error) {
 	return a, nil
 }
 
-var _v3110OpenshiftApiserverTrustedCaCmYaml = []byte(`apiVersion: v1
-kind: ConfigMap
-metadata:
-  namespace: openshift-apiserver
-  name: trusted-ca-bundle
-  labels:
-    config.openshift.io/inject-trusted-cabundle: "true"
-`)
-
-func v3110OpenshiftApiserverTrustedCaCmYamlBytes() ([]byte, error) {
-	return _v3110OpenshiftApiserverTrustedCaCmYaml, nil
-}
-
-func v3110OpenshiftApiserverTrustedCaCmYaml() (*asset, error) {
-	bytes, err := v3110OpenshiftApiserverTrustedCaCmYamlBytes()
-	if err != nil {
-		return nil, err
-	}
-
-	info := bindataFileInfo{name: "v3.11.0/openshift-apiserver/trusted-ca-cm.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
-	a := &asset{bytes: bytes, info: info}
-	return a, nil
-}
-
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -481,7 +456,6 @@ var _bindata = map[string]func() (*asset, error){
 	"v3.11.0/openshift-apiserver/ns.yaml":                           v3110OpenshiftApiserverNsYaml,
 	"v3.11.0/openshift-apiserver/sa.yaml":                           v3110OpenshiftApiserverSaYaml,
 	"v3.11.0/openshift-apiserver/svc.yaml":                          v3110OpenshiftApiserverSvcYaml,
-	"v3.11.0/openshift-apiserver/trusted-ca-cm.yaml":                v3110OpenshiftApiserverTrustedCaCmYaml,
 }
 
 // AssetDir returns the file names below a certain
@@ -534,7 +508,6 @@ var _bintree = &bintree{nil, map[string]*bintree{
 			"ns.yaml":                           {v3110OpenshiftApiserverNsYaml, map[string]*bintree{}},
 			"sa.yaml":                           {v3110OpenshiftApiserverSaYaml, map[string]*bintree{}},
 			"svc.yaml":                          {v3110OpenshiftApiserverSvcYaml, map[string]*bintree{}},
-			"trusted-ca-cm.yaml":                {v3110OpenshiftApiserverTrustedCaCmYaml, map[string]*bintree{}},
 		}},
 	}},
 }}


### PR DESCRIPTION
The trusted-ca-bundle was never created in the operator NS where
we were trying to sync it from. Have it be created by the CVO in
the operator NS and sync only its data (therefore not the injection
label) to the operand's NS.