### PR TITLE
Bug 1747260: Last (?) fix to trusted-ca CM syncing

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,9 +1,9 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.11 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.12 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-openshift-apiserver-operator
 COPY . .
 RUN go build ./cmd/cluster-openshift-apiserver-operator
 
-FROM registry.svc.ci.openshift.org/ocp/4.0:base
+FROM registry.svc.ci.openshift.org/ocp/4.2:base
 COPY --from=builder /go/src/github.com/openshift/cluster-openshift-apiserver-operator/cluster-openshift-apiserver-operator /usr/bin/
 COPY manifests /manifests
 LABEL io.openshift.release.operator true

--- a/pkg/operator/workloadcontroller/workload_controller_openshiftapiserver_v311_00.go
+++ b/pkg/operator/workloadcontroller/workload_controller_openshiftapiserver_v311_00.go
@@ -297,6 +297,7 @@ func syncOpenShiftAPIServerTrustedCA_v311_00_to_latest(client coreclientv1.CoreV
 
 	// get the copy of the sourceCM, remove the annotations and labels we set for CVO and network operator
 	requiredCM := sourceCM.DeepCopy()
+	requiredCM.UID = ""
 	requiredCM.ObjectMeta.ResourceVersion = ""
 	requiredCM.ObjectMeta.Namespace = operatorclient.TargetNamespace
 	delete(requiredCM.Annotations, "release.openshift.io/create-only")
@@ -315,6 +316,7 @@ func syncOpenShiftAPIServerTrustedCA_v311_00_to_latest(client coreclientv1.CoreV
 
 	// if the target CM Data differs, update it
 	if !reflect.DeepEqual(sourceCM.Data, imageCM.Data) {
+		requiredCM.UID = imageCM.UID
 		requiredCM.ResourceVersion = imageCM.ResourceVersion
 		_, err = targetClient.Update(requiredCM)
 	}


### PR DESCRIPTION
Can't have source CM UID in metadata when updating the image CM

-----

Tested manually