### PR TITLE
add correct label to ds config initContainer

### DIFF
--- a/bindata/v3.11.0/openshift-apiserver/ds.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/ds.yaml
@@ -28,6 +28,8 @@ spec:
           image: ${IMAGE}
           imagePullPolicy: IfNotPresent
           command: ['sh', '-c', 'chmod 0700 /var/log/openshift-apiserver']
+          securityContext:
+            privileged: true
           volumeMounts:
             - mountPath: /var/log/openshift-apiserver
               name: audit-dir

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -205,6 +205,8 @@ spec:
           image: ${IMAGE}
           imagePullPolicy: IfNotPresent
           command: ['sh', '-c', 'chmod 0700 /var/log/openshift-apiserver']
+          securityContext:
+            privileged: true
           volumeMounts:
             - mountPath: /var/log/openshift-apiserver
               name: audit-dir


### PR DESCRIPTION
CRI-O 1.16 made a change to how selinux labels were handled that increased security. In doing so, pod specs need to enable selinuxRelabel. In the case of this initContainer, it is trying to edit the permissions of a file on the host system, which is a security flaw, and thus selinux is denying it.

Add the type spc_t, which allows the container to modify the host file

Signed-off-by: Peter Hunt <pehunt@redhat.com>