### PR TITLE
auditConfig: Log write operations of Identities with RequestResponse

### DIFF
--- a/bindata/v3.11.0/openshift-apiserver/defaultconfig.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/defaultconfig.yaml
@@ -42,6 +42,13 @@ auditConfig:
           - "/api*" # Wildcard matching.
           - "/version"
           - "/healthz"
+      # Log the full Identity API resource object so that the audit trail
+      # allows us to match the username with the IDP identity.
+      - level: RequestResponse
+        verbs: ["create", "update", "patch"]
+        resources:
+          - group: "user.openshift.io"
+            resources: ["identities"]
       # A catch-all rule to log all other requests at the Metadata level.
       - level: Metadata
         # Long-running requests like watches that fall under this rule will not

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -146,6 +146,13 @@ auditConfig:
           - "/api*" # Wildcard matching.
           - "/version"
           - "/healthz"
+      # Log the full Identity API resource object so that the audit trail
+      # allows us to match the username with the IDP identity.
+      - level: RequestResponse
+        verbs: ["create", "update", "patch"]
+        resources:
+          - group: "user.openshift.io"
+            resources: ["identities"]
       # A catch-all rule to log all other requests at the Metadata level.
       - level: Metadata
         # Long-running requests like watches that fall under this rule will not


### PR DESCRIPTION
In order to be able to match a user from IDP with a username which is
normally logged in the audit logs, we need to have the creation of the
Identity API resource logged.

This patch changes the hardcoded auditConfig to log "witethe "identities"
resource of the "user.openshift.io" group at the RequestResponse level.