### PR TITLE
Add default ClusterRole and ClusterRoleBinding for motd

### DIFF
--- a/manifests/0000_30_openshift-apiserver-operator_04_motd_role.yaml
+++ b/manifests/0000_30_openshift-apiserver-operator_04_motd_role.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: motd-reader
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  resourceNames: ["motd"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: read-motd-global
+subjects:
+- kind: Group
+  name: system:authenticated
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: motd-reader
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
With https://github.com/openshift/oc/pull/67 came the addition of the
capability to display a message of the day via the `oc` command. This
message of the day serves the purpose of presenting a legal notice
that's required for regulatory compliance.

In order for this legal notice to be usable out of the box, we need to
grant folks read-only access to it. This PR adds that by creating a
default ClusterRole and ClusterRoleBinding that enables this.