### PR TITLE
Add manifest annotations for hosted deployment exclusions

### DIFF
--- a/manifests/0000_30_openshift-apiserver-operator_07_deployment.yaml
+++ b/manifests/0000_30_openshift-apiserver-operator_07_deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   name: openshift-apiserver-operator
   labels:
     app: openshift-apiserver-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   replicas: 1
   strategy:

--- a/manifests/0000_30_openshift-apiserver-operator_08_clusteroperator.yaml
+++ b/manifests/0000_30_openshift-apiserver-operator_08_clusteroperator.yaml
@@ -2,6 +2,8 @@ apiVersion: config.openshift.io/v1
 kind: ClusterOperator
 metadata:
   name: openshift-apiserver
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec: {}
 status:
   versions:


### PR DESCRIPTION
Enables the CVO to exclude manifests in an externally hosted control plane deployment
See https://github.com/openshift/cluster-version-operator/pull/252