### PR TITLE
use upstream cluster authentication config

### DIFF
--- a/bindata/v3.11.0/openshift-apiserver/defaultconfig.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/defaultconfig.yaml
@@ -1,17 +1,5 @@
 apiVersion: openshiftcontrolplane.config.openshift.io/v1
 kind: OpenShiftAPIServerConfig
-aggregatorConfig:
-  clientCA: /var/run/configmaps/aggregator-client-ca/ca-bundle.crt
-  allowedNames:
-  - kube-apiserver-proxy
-  - system:kube-apiserver-proxy
-  - system:openshift-aggregator
-  usernameHeaders:
-  - X-Remote-User
-  groupHeaders:
-  - X-Remote-Group
-  extraHeaderPrefixes:
-  - X-Remote-Extra-
 auditConfig:
   auditFilePath: "/var/log/openshift-apiserver/audit.log"
   enabled: true

--- a/bindata/v3.11.0/openshift-apiserver/ds.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/ds.yaml
@@ -56,10 +56,6 @@ spec:
         ports:
         - containerPort: 8443
         volumeMounts:
-        - mountPath: /var/run/configmaps/aggregator-client-ca
-          name: aggregator-client-ca
-        - mountPath: /var/run/configmaps/client-ca
-          name: client-ca
         - mountPath: /var/run/configmaps/config
           name: config
         - mountPath: /var/run/secrets/etcd-client
@@ -90,12 +86,6 @@ spec:
             path: healthz
       terminationGracePeriodSeconds: 70 # a bit more than the 60 seconds timeout of non-long-running requests
       volumes:
-      - name: aggregator-client-ca
-        configMap:
-          name: aggregator-client-ca
-      - name: client-ca
-        configMap:
-          name: client-ca
       - name: config
         configMap:
           name: config

--- a/pkg/cmd/resourcegraph/resourcegraph.go
+++ b/pkg/cmd/resourcegraph/resourcegraph.go
@@ -43,9 +43,6 @@ func Resources() resourcegraph.Resources {
 	cvo := resourcegraph.NewOperator("cluster-version").
 		From(payload).
 		Add(ret)
-	kasOperator := resourcegraph.NewOperator("kube-apiserver").
-		From(cvo).
-		Add(ret)
 	serviceCAOperator := resourcegraph.NewOperator("service-ca").
 		From(cvo).
 		Add(ret)
@@ -84,26 +81,6 @@ func Resources() resourcegraph.Resources {
 		From(fromEtcdClient).
 		Add(ret)
 
-	// aggregator CA
-	kasAggregatorCA := resourcegraph.NewConfigMap(operatorclient.GlobalUserSpecifiedConfigNamespace, "kube-apiserver-aggregator-client-ca").
-		Note("Synchronized").
-		From(kasOperator).
-		Add(ret)
-	aggregatorCA := resourcegraph.NewConfigMap(operatorclient.TargetNamespace, "aggregator-client-ca").
-		Note("Synchronized").
-		From(kasAggregatorCA).
-		Add(ret)
-
-	// client CA
-	kasClientCA := resourcegraph.NewConfigMap(operatorclient.GlobalUserSpecifiedConfigNamespace, "kube-apiserver-client-ca").
-		Note("Synchronized").
-		From(kasOperator).
-		Add(ret)
-	clientCA := resourcegraph.NewConfigMap(operatorclient.TargetNamespace, "client-ca").
-		Note("Synchronized").
-		From(kasClientCA).
-		Add(ret)
-
 	// serving cert
 	serviceCAController := resourcegraph.NewResource(resourcegraph.NewCoordinates("apps", "deployments", "openshift-service-cert-signer", "service-serving-cert-signer")).
 		From(serviceCAOperator).
@@ -123,8 +100,6 @@ func Resources() resourcegraph.Resources {
 
 	// and finally our target pod
 	_ = resourcegraph.NewResource(resourcegraph.NewCoordinates("", "pods", operatorclient.TargetNamespace, "openshift-apiserver")).
-		From(aggregatorCA).
-		From(clientCA).
 		From(etcdServingCA).
 		From(etcdClient).
 		From(servingCert).

--- a/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
+++ b/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
@@ -38,18 +38,6 @@ func NewResourceSyncController(
 	); err != nil {
 		return nil, nil, err
 	}
-	if err := resourceSyncController.SyncConfigMap(
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "client-ca"},
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace, Name: "kube-apiserver-client-ca"},
-	); err != nil {
-		return nil, nil, err
-	}
-	if err := resourceSyncController.SyncConfigMap(
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "aggregator-client-ca"},
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace, Name: "kube-apiserver-aggregator-client-ca"},
-	); err != nil {
-		return nil, nil, err
-	}
 
 	return resourceSyncController, resourcesynccontroller.NewDebugHandler(resourceSyncController), nil
 }

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -104,18 +104,6 @@ func v3110OpenshiftApiserverCmYaml() (*asset, error) {
 
 var _v3110OpenshiftApiserverDefaultconfigYaml = []byte(`apiVersion: openshiftcontrolplane.config.openshift.io/v1
 kind: OpenShiftAPIServerConfig
-aggregatorConfig:
-  clientCA: /var/run/configmaps/aggregator-client-ca/ca-bundle.crt
-  allowedNames:
-  - kube-apiserver-proxy
-  - system:kube-apiserver-proxy
-  - system:openshift-aggregator
-  usernameHeaders:
-  - X-Remote-User
-  groupHeaders:
-  - X-Remote-Group
-  extraHeaderPrefixes:
-  - X-Remote-Extra-
 auditConfig:
   auditFilePath: "/var/log/openshift-apiserver/audit.log"
   enabled: true
@@ -240,10 +228,6 @@ spec:
         ports:
         - containerPort: 8443
         volumeMounts:
-        - mountPath: /var/run/configmaps/aggregator-client-ca
-          name: aggregator-client-ca
-        - mountPath: /var/run/configmaps/client-ca
-          name: client-ca
         - mountPath: /var/run/configmaps/config
           name: config
         - mountPath: /var/run/secrets/etcd-client
@@ -274,12 +258,6 @@ spec:
             path: healthz
       terminationGracePeriodSeconds: 70 # a bit more than the 60 seconds timeout of non-long-running requests
       volumes:
-      - name: aggregator-client-ca
-        configMap:
-          name: aggregator-client-ca
-      - name: client-ca
-        configMap:
-          name: client-ca
       - name: config
         configMap:
           name: config

--- a/pkg/operator/workloadcontroller/workload_controller_openshiftapiserver_v311_00.go
+++ b/pkg/operator/workloadcontroller/workload_controller_openshiftapiserver_v311_00.go
@@ -78,7 +78,7 @@ func syncOpenShiftAPIServer_v311_00_to_latest(c OpenShiftAPIServerOperator, orig
 
 	imageImportCAModifiedObject, imageImportCAModified, err := manageOpenShiftAPIServerImageImportCA_v311_00_to_latest(c.openshiftConfigClient, c.kubeClient.CoreV1(), c.eventRecorder)
 	if err != nil {
-		errors = append(errors, fmt.Errorf("%q: %v", "client-ca", err))
+		errors = append(errors, fmt.Errorf("%q: %v", "image-import-ca", err))
 	}
 	if imageImportCAModified {
 		reasonsForForcedRollingUpdate = append(reasonsForForcedRollingUpdate, "modified: "+resourceSelectorForCLI(imageImportCAModifiedObject))


### PR DESCRIPTION
Remove configuration for the side-channel cluster-authentication and instead use the "standard" upstream, zero-config option.