### PR TITLE
WIP: Bug 1776797: encryption: speed-up, Encrypted condition, allow backup/restore

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -22,7 +22,7 @@ import:
 - package: github.com/openshift/client-go
   version: master
 - package: github.com/openshift/library-go
-  version: master
+  version: release-4.3
 - package: github.com/jteeuwen/go-bindata
   version: a0ff2567cfb70903282db057e799fd826784d41d
 - package: k8s.io/gengo/args


### PR DESCRIPTION
- speeding up migration by a factor: 50k objects in half an hour (before around 1k in 5m)
- added Encrypted condition for the user to see the encryption status
- leave last read-key in encryption config in order to allow backup/restore when encryption-config backup is done after backup, without losing data (compare openshift/enhancements#131).

TODOs:

[ ] pick https://github.com/openshift/cluster-openshift-apiserver-operator/pull/261
[ ] pick openshift/library-go#622