### PR TITLE
Specify "bindNetwork: tcp" so apiserver will work on IPv6 single-stack

### DIFF
--- a/bindata/v3.11.0/openshift-apiserver/defaultconfig.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/defaultconfig.yaml
@@ -49,3 +49,5 @@ storageConfig:
 apiServerArguments:
   minimal-shutdown-duration:
   - 3s # give SDN some time to converge
+servingInfo:
+  bindNetwork: "tcp"

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -153,6 +153,8 @@ storageConfig:
 apiServerArguments:
   minimal-shutdown-duration:
   - 3s # give SDN some time to converge
+servingInfo:
+  bindNetwork: "tcp"
 `)
 
 func v3110OpenshiftApiserverDefaultconfigYamlBytes() ([]byte, error) {


### PR DESCRIPTION
If you say `net.Listen("tcp", "0.0.0.0:8443")`, golang will actually create a dual-stack IPv4/IPv6 listening socket. But for historical reasons (having to do with bad IPv6 compat in older kube I think), we default to passing `"tcp4"` (the default value of `configv1.ServingInfo.BindNetwork`) instead of `"tcp"`, forcing IPv4-only.

There is no reason these days for servers on the pod network to enforce IPv4-only, so this overrides the default for openshift-apiserver.

This will need to be backported to 4.3.

cc @russellb 