### PR TITLE
Replace --{minimal-shutdown -> shutdown-delay}-duration

### DIFF
--- a/bindata/v3.11.0/openshift-apiserver/defaultconfig.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/defaultconfig.yaml
@@ -47,5 +47,5 @@ storageConfig:
   urls:
     - https://etcd.openshift-etcd.svc:2379
 apiServerArguments:
-  minimal-shutdown-duration:
+  shutdown-delay-duration:
   - 3s # give SDN some time to converge

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -151,7 +151,7 @@ storageConfig:
   urls:
     - https://etcd.openshift-etcd.svc:2379
 apiServerArguments:
-  minimal-shutdown-duration:
+  shutdown-delay-duration:
   - 3s # give SDN some time to converge
 `)
 


### PR DESCRIPTION
The latter is the official flag name, the former from our carry patch.