### PR TITLE
DEVEXP-424: Mounting node pull secrets

### DIFF
--- a/bindata/v3.11.0/openshift-apiserver/deploy.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/deploy.yaml
@@ -65,6 +65,9 @@ spec:
         ports:
         - containerPort: 8443
         volumeMounts:
+        - mountPath: /var/lib/kubelet/config.json
+          name: node-pullsecrets
+          readOnly: true
         - mountPath: /var/run/configmaps/config
           name: config
         - mountPath: /var/run/secrets/etcd-client
@@ -95,6 +98,10 @@ spec:
             path: healthz
       terminationGracePeriodSeconds: 70 # a bit more than the 60 seconds timeout of non-long-running requests
       volumes:
+      - name: node-pullsecrets
+        hostPath:
+          path: /var/lib/kubelet/config.json
+          type: File
       - name: config
         configMap:
           name: config

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -240,6 +240,9 @@ spec:
         ports:
         - containerPort: 8443
         volumeMounts:
+        - mountPath: /var/lib/kubelet/config.json
+          name: node-pullsecrets
+          readOnly: true
         - mountPath: /var/run/configmaps/config
           name: config
         - mountPath: /var/run/secrets/etcd-client
@@ -270,6 +273,10 @@ spec:
             path: healthz
       terminationGracePeriodSeconds: 70 # a bit more than the 60 seconds timeout of non-long-running requests
       volumes:
+      - name: node-pullsecrets
+        hostPath:
+          path: /var/lib/kubelet/config.json
+          type: File
       - name: config
         configMap:
           name: config


### PR DESCRIPTION
OpenShift API Server needs to make use of node pull credentials during `image stream import`. This PR mounts them inside the operand pods. For further details please refer to the [enhancement proposal](https://github.com/openshift/enhancements/pull/136).

Note: Please review https://github.com/openshift/openshift-apiserver/pull/83 as well