### PR TITLE
replace verbosity based on string substitution for ease

### DIFF
--- a/bindata/v3.11.0/openshift-apiserver/ds.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/ds.yaml
@@ -45,7 +45,7 @@ spec:
               echo "Copying system trust bundle"
               cp -f /var/run/configmaps/trusted-ca-bundle/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
             fi
-            exec openshift-apiserver start --config=/var/run/configmaps/config/config.yaml
+            exec openshift-apiserver start --config=/var/run/configmaps/config/config.yaml -v=${VERBOSITY}
         resources:
           requests:
             memory: 200Mi

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -217,7 +217,7 @@ spec:
               echo "Copying system trust bundle"
               cp -f /var/run/configmaps/trusted-ca-bundle/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
             fi
-            exec openshift-apiserver start --config=/var/run/configmaps/config/config.yaml
+            exec openshift-apiserver start --config=/var/run/configmaps/config/config.yaml -v=${VERBOSITY}
         resources:
           requests:
             memory: 200Mi


### PR DESCRIPTION
This makes the verbosity easy for workloads to add in their operator manifest.