### PR TITLE
bug 1792386: set the operand version and make the CVO wait

### DIFF
--- a/manifests/0000_30_openshift-apiserver-operator_08_clusteroperator.yaml
+++ b/manifests/0000_30_openshift-apiserver-operator_08_clusteroperator.yaml
@@ -9,3 +9,5 @@ status:
   versions:
     - name: operator
       version: "0.0.1-snapshot"
+    - name: openshift-apiserver
+      version: "0.0.1-snapshot"

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -121,7 +121,7 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 	versionRecorder.SetVersion("operator", os.Getenv("OPERATOR_IMAGE_VERSION"))
 
 	workloadController := workloadcontroller.NewWorkloadController(
-		os.Getenv("IMAGE"), os.Getenv("OPERATOR_IMAGE"),
+		os.Getenv("IMAGE"), os.Getenv("OPERATOR_IMAGE_VERSION"), os.Getenv("OPERATOR_IMAGE"),
 		operatorClient,
 		versionRecorder,
 		operatorConfigInformers.Operator().V1().OpenShiftAPIServers(),

--- a/pkg/operator/workloadcontroller/workload_controller.go
+++ b/pkg/operator/workloadcontroller/workload_controller.go
@@ -39,7 +39,7 @@ const (
 )
 
 type OpenShiftAPIServerOperator struct {
-	targetImagePullSpec, operatorImagePullSpec string
+	targetImagePullSpec, targetOperandVersion, operatorImagePullSpec string
 
 	operatorClient        v1helpers.OperatorClient
 	versionRecorder       status.VersionGetter
@@ -53,7 +53,7 @@ type OpenShiftAPIServerOperator struct {
 }
 
 func NewWorkloadController(
-	targetImagePullSpec, operatorImagePullSpec string,
+	targetImagePullSpec, targetOperandVersion, operatorImagePullSpec string,
 	operatorClient v1helpers.OperatorClient,
 	versionRecorder status.VersionGetter,
 	operatorConfigInformer operatorv1informers.OpenShiftAPIServerInformer,
@@ -69,6 +69,7 @@ func NewWorkloadController(
 ) *OpenShiftAPIServerOperator {
 	c := &OpenShiftAPIServerOperator{
 		targetImagePullSpec:   targetImagePullSpec,
+		targetOperandVersion:  targetOperandVersion,
 		operatorImagePullSpec: operatorImagePullSpec,
 
 		operatorClient:        operatorClient,

--- a/pkg/operator/workloadcontroller/workload_controller.go
+++ b/pkg/operator/workloadcontroller/workload_controller.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+
 	"github.com/openshift/library-go/pkg/operator/status"
 
 	"github.com/openshift/cluster-openshift-apiserver-operator/pkg/operator/operatorclient"
@@ -32,14 +34,14 @@ import (
 )
 
 const (
-	workloadDegradedCondition = "WorkloadDegraded"
-	imageImportCAName         = "image-import-ca"
-	workQueueKey              = "key"
+	imageImportCAName = "image-import-ca"
+	workQueueKey      = "key"
 )
 
 type OpenShiftAPIServerOperator struct {
 	targetImagePullSpec, operatorImagePullSpec string
 
+	operatorClient        v1helpers.OperatorClient
 	versionRecorder       status.VersionGetter
 	operatorConfigClient  operatorv1client.OpenShiftAPIServersGetter
 	openshiftConfigClient openshiftconfigclientv1.ConfigV1Interface
@@ -52,6 +54,7 @@ type OpenShiftAPIServerOperator struct {
 
 func NewWorkloadController(
 	targetImagePullSpec, operatorImagePullSpec string,
+	operatorClient v1helpers.OperatorClient,
 	versionRecorder status.VersionGetter,
 	operatorConfigInformer operatorv1informers.OpenShiftAPIServerInformer,
 	kubeInformersForOpenShiftAPIServerNamespace kubeinformers.SharedInformerFactory,
@@ -68,6 +71,7 @@ func NewWorkloadController(
 		targetImagePullSpec:   targetImagePullSpec,
 		operatorImagePullSpec: operatorImagePullSpec,
 
+		operatorClient:        operatorClient,
 		versionRecorder:       versionRecorder,
 		operatorConfigClient:  operatorConfigClient,
 		openshiftConfigClient: openshiftConfigClient,
@@ -139,12 +143,7 @@ func (c OpenShiftAPIServerOperator) sync() error {
 		return nil
 	}
 
-	forceRequeue, err := syncOpenShiftAPIServer_v311_00_to_latest(c, operatorConfig)
-	if forceRequeue && err != nil {
-		c.queue.AddRateLimited(workQueueKey)
-	}
-
-	return err
+	return syncOpenShiftAPIServer_v311_00_to_latest(c, operatorConfig)
 }
 
 // Run starts the openshift-apiserver and blocks until stopCh is closed.
@@ -157,6 +156,8 @@ func (c *OpenShiftAPIServerOperator) Run(ctx context.Context, workers int) {
 
 	// doesn't matter what workers say, only start one.
 	go wait.Until(c.runWorker, time.Second, ctx.Done())
+
+	go wait.Until(func() { c.queue.Add(workQueueKey) }, time.Minute, ctx.Done())
 
 	<-ctx.Done()
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/staleconditions/remove_stale_conditions.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staleconditions/remove_stale_conditions.go
@@ -1,0 +1,116 @@
+package staleconditions
+
+import (
+	"fmt"
+	"time"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+const workQueueKey = "key"
+
+type RemoveStaleConditions struct {
+	conditions []string
+
+	operatorClient v1helpers.OperatorClient
+	cachesToSync   []cache.InformerSynced
+
+	eventRecorder events.Recorder
+	// queue only ever has one item, but it has nice error handling backoff/retry semantics
+	queue workqueue.RateLimitingInterface
+}
+
+func NewRemoveStaleConditions(
+	conditions []string,
+	operatorClient v1helpers.OperatorClient,
+	eventRecorder events.Recorder,
+) *RemoveStaleConditions {
+	c := &RemoveStaleConditions{
+		conditions: conditions,
+
+		operatorClient: operatorClient,
+		eventRecorder:  eventRecorder,
+		cachesToSync:   []cache.InformerSynced{operatorClient.Informer().HasSynced},
+
+		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "RemoveStaleConditions"),
+	}
+
+	operatorClient.Informer().AddEventHandler(c.eventHandler())
+
+	return c
+}
+
+func (c RemoveStaleConditions) sync() error {
+	removeStaleConditionsFn := func(status *operatorv1.OperatorStatus) error {
+		for _, condition := range c.conditions {
+			v1helpers.RemoveOperatorCondition(&status.Conditions, condition)
+		}
+		return nil
+	}
+
+	if _, _, err := v1helpers.UpdateStatus(c.operatorClient, removeStaleConditionsFn); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Run starts the kube-scheduler and blocks until stopCh is closed.
+func (c *RemoveStaleConditions) Run(workers int, stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	klog.Infof("Starting RemoveStaleConditions")
+	defer klog.Infof("Shutting down RemoveStaleConditions")
+
+	if !cache.WaitForCacheSync(stopCh, c.cachesToSync...) {
+		utilruntime.HandleError(fmt.Errorf("caches did not sync"))
+		return
+	}
+
+	// doesn't matter what workers say, only start one.
+	go wait.Until(c.runWorker, time.Second, stopCh)
+
+	<-stopCh
+}
+
+func (c *RemoveStaleConditions) runWorker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *RemoveStaleConditions) processNextWorkItem() bool {
+	dsKey, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(dsKey)
+
+	err := c.sync()
+	if err == nil {
+		c.queue.Forget(dsKey)
+		return true
+	}
+
+	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
+	c.queue.AddRateLimited(dsKey)
+
+	return true
+}
+
+// eventHandler queues the operator to check spec and status
+func (c *RemoveStaleConditions) eventHandler() cache.ResourceEventHandler {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { c.queue.Add(workQueueKey) },
+		UpdateFunc: func(old, new interface{}) { c.queue.Add(workQueueKey) },
+		DeleteFunc: func(obj interface{}) { c.queue.Add(workQueueKey) },
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -262,6 +262,7 @@ github.com/openshift/library-go/pkg/operator/resource/resourcemerge
 github.com/openshift/library-go/pkg/operator/resource/resourceread
 github.com/openshift/library-go/pkg/operator/resourcesynccontroller
 github.com/openshift/library-go/pkg/operator/revisioncontroller
+github.com/openshift/library-go/pkg/operator/staleconditions
 github.com/openshift/library-go/pkg/operator/staticpod/controller/revision
 github.com/openshift/library-go/pkg/operator/status
 github.com/openshift/library-go/pkg/operator/unsupportedconfigoverridescontroller


### PR DESCRIPTION
builds on #301 

The last commit is unique and sets the operand to the same version as the operator when it has achieved its consistent level.

/assign @mfojtik 