### PR TITLE
Bug 1798215: Add a new label 'apiserver' to identify the source

### DIFF
--- a/manifests/0000_90_openshift-apiserver-operator_04_servicemonitor-apiserver.yaml
+++ b/manifests/0000_90_openshift-apiserver-operator_04_servicemonitor-apiserver.yaml
@@ -51,6 +51,10 @@ spec:
       regex: apiserver_admission_step_admission_latencies_seconds_.*
       sourceLabels:
       - __name__
+    relabelings:
+    - action: replace
+      targetLabel: apiserver
+      replacement: openshift-apiserver
     port: https
     scheme: https
     tlsConfig:


### PR DESCRIPTION
Add a new label 'apiserver' to apiserver_current_inflight_requests
metric to identify that the source is openshift apiserver.

The label would say - apiserver:openshift-apiserver

Do the similar for kube-apiserver - apiserver:kube-apiserver