### PR TITLE
bug 1804717: Switch to managing openshift-apiserver pods with a deployment

### DIFF
--- a/bindata/v3.11.0/openshift-apiserver/deploy.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/deploy.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: DaemonSet
+kind: Deployment
 metadata:
   namespace: openshift-apiserver
   name: apiserver
@@ -7,17 +7,26 @@ metadata:
     app: openshift-apiserver
     apiserver: "true"
 spec:
-  updateStrategy:
-    type: RollingUpdate
+  replicas: 3
   selector:
     matchLabels:
-      app: openshift-apiserver
+      # Need to vary the app label from that used by the legacy
+      # daemonset ('openshift-apiserver') to avoid the legacy
+      # daemonset and its replacement deployment trying to try to
+      # manage the same pods.
+      #
+      # It's also necessary to use different labeling to ensure, via
+      # anti-affinity, at most one deployment-managed pod on each
+      # master node. Without label differentiation, anti-affinity
+      # would prevent a deployment-managed pod from running on a node
+      # that was already running a daemonset-managed pod.
+      app: openshift-apiserver-a
       apiserver: "true"
   template:
     metadata:
       name: openshift-apiserver
       labels:
-        app: openshift-apiserver
+        app: openshift-apiserver-a
         apiserver: "true"
     spec:
       serviceAccountName: openshift-apiserver-sa
@@ -119,4 +128,20 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
       tolerations:
-      - operator: Exists
+        # Ensure pod can be scheduled on master nodes
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"
+        # Ensure pod can be evicted if the node is unreachable
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120
+        # Ensure scheduling is delayed until node readiness
+        # (i.e. network operator configures CNI on the node)
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120
+      # Anti-affinity is configured in code due to the need to scope
+      # selection to the computed pod template.

--- a/pkg/operator/apiservicecontroller/apiservice_controller_test.go
+++ b/pkg/operator/apiservicecontroller/apiservice_controller_test.go
@@ -359,7 +359,6 @@ func TestAvailableStatus(t *testing.T) {
 		expectedMessages    []string
 		existingAPIServices []runtime.Object
 		apiServiceReactor   kubetesting.ReactionFunc
-		daemonReactor       kubetesting.ReactionFunc
 	}{
 		{
 			name:           "Default",

--- a/pkg/operator/deploynodeprovider.go
+++ b/pkg/operator/deploynodeprovider.go
@@ -12,18 +12,18 @@ import (
 	"github.com/openshift/cluster-openshift-apiserver-operator/pkg/operator/operatorclient"
 )
 
-// DaemonSetNodeProvider returns the node list from nodes matching the node selector of a DaemonSet
-type DaemonSetNodeProvider struct {
-	TargetNamespaceDaemonSetInformer appsv1informers.DaemonSetInformer
-	NodeInformer                     corev1informers.NodeInformer
+// DeploymentNodeProvider returns the node list from nodes matching the node selector of a Deployment
+type DeploymentNodeProvider struct {
+	TargetNamespaceDeploymentInformer appsv1informers.DeploymentInformer
+	NodeInformer                      corev1informers.NodeInformer
 }
 
 var (
-	_ encryptiondeployer.MasterNodeProvider = &DaemonSetNodeProvider{}
+	_ encryptiondeployer.MasterNodeProvider = &DeploymentNodeProvider{}
 )
 
-func (p DaemonSetNodeProvider) MasterNodeNames() ([]string, error) {
-	ds, err := p.TargetNamespaceDaemonSetInformer.Lister().DaemonSets(operatorclient.TargetNamespace).Get("apiserver")
+func (p DeploymentNodeProvider) MasterNodeNames() ([]string, error) {
+	ds, err := p.TargetNamespaceDeploymentInformer.Lister().Deployments(operatorclient.TargetNamespace).Get("apiserver")
 	if err != nil && errors.IsNotFound(err) {
 		return nil, nil
 	}
@@ -44,12 +44,12 @@ func (p DaemonSetNodeProvider) MasterNodeNames() ([]string, error) {
 	return ret, nil
 }
 
-func (p DaemonSetNodeProvider) AddEventHandler(handler cache.ResourceEventHandler) []cache.InformerSynced {
-	p.TargetNamespaceDaemonSetInformer.Informer().AddEventHandler(handler)
+func (p DeploymentNodeProvider) AddEventHandler(handler cache.ResourceEventHandler) []cache.InformerSynced {
+	p.TargetNamespaceDeploymentInformer.Informer().AddEventHandler(handler)
 	p.NodeInformer.Informer().AddEventHandler(handler)
 
 	return []cache.InformerSynced{
-		p.TargetNamespaceDaemonSetInformer.Informer().HasSynced,
+		p.TargetNamespaceDeploymentInformer.Informer().HasSynced,
 		p.NodeInformer.Informer().HasSynced,
 	}
 }

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/encryption"
 	"github.com/openshift/library-go/pkg/operator/encryption/controllers/migrators"
 	encryptiondeployer "github.com/openshift/library-go/pkg/operator/encryption/deployer"
+	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/genericoperatorclient"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/revisioncontroller"
@@ -38,7 +39,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	apiregistrationclient "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
 	apiregistrationinformers "k8s.io/kube-aggregator/pkg/client/informers/externalversions"
@@ -199,9 +202,9 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		controllerConfig.EventRecorder,
 	)
 
-	nodeProvider := DaemonSetNodeProvider{
-		TargetNamespaceDaemonSetInformer: kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Apps().V1().DaemonSets(),
-		NodeInformer:                     kubeInformersForNamespaces.InformersFor("").Core().V1().Nodes(),
+	nodeProvider := DeploymentNodeProvider{
+		TargetNamespaceDeploymentInformer: kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Apps().V1().Deployments(),
+		NodeInformer:                      kubeInformersForNamespaces.InformersFor("").Core().V1().Nodes(),
 	}
 
 	deployer, err := encryptiondeployer.NewRevisionLabelPodDeployer("revision", operatorclient.TargetNamespace, kubeInformersForNamespaces, resourceSyncController, kubeClient.CoreV1(), kubeClient.CoreV1(), nodeProvider)
@@ -246,6 +249,10 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 			"Progressing",
 			// in 4.1.0-4.3.0 this was used for indicating the apiserver daemonset was available
 			"Available",
+			// in 4.1.0-4.3.z this was used for indicating the conditions of the apiserver daemonset.
+			"APIServerDaemonSetAvailable",
+			"APIServerDaemonSetProgressing",
+			"APIServerDaemonSetDegraded",
 		},
 		operatorClient,
 		controllerConfig.EventRecorder,
@@ -254,6 +261,8 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 	if controllerConfig.Server != nil {
 		controllerConfig.Server.Handler.NonGoRestfulMux.Handle("/debug/controllers/resourcesync", debugHandler)
 	}
+
+	ensureDaemonSetCleanup(kubeClient, ctx, controllerConfig.EventRecorder)
 
 	operatorConfigInformers.Start(ctx.Done())
 	kubeInformersForNamespaces.Start(ctx.Done())
@@ -325,4 +334,60 @@ func apiServicesReferences() []configv1.ObjectReference {
 		ret = append(ret, configv1.ObjectReference{Group: "apiregistration.k8s.io", Resource: "apiservices", Name: apiService.Spec.Version + "." + apiService.Spec.Group})
 	}
 	return ret
+}
+
+// ensureDaemonSetCleanup continually ensures the removal of the daemonset
+// used to manage apiserver pods in releases prior to 4.5. The daemonset is
+// removed once the deployment now managing apiserver pods reports at least
+// one pod available.
+func ensureDaemonSetCleanup(kubeClient *kubernetes.Clientset, ctx context.Context, eventRecorder events.Recorder) {
+	// daemonset and deployment both use the same name
+	resourceName := "apiserver"
+
+	dsClient := kubeClient.AppsV1().DaemonSets(operatorclient.TargetNamespace)
+	deployClient := kubeClient.AppsV1().Deployments(operatorclient.TargetNamespace)
+
+	go wait.UntilWithContext(ctx, func(_ context.Context) {
+		// This function isn't expected to take long enough to suggest
+		// checking that the context is done. The wait method will do that
+		// checking.
+
+		// Check whether the legacy daemonset exists and is not marked for deletion
+		ds, err := dsClient.Get(resourceName, metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			// Done - daemonset does not exist
+			return
+		}
+		if err != nil {
+			klog.Warningf("Error retrieving legacy daemonset: %v", err)
+			return
+		}
+		if ds.ObjectMeta.DeletionTimestamp != nil {
+			// Done - daemonset has been marked for deletion
+			return
+		}
+
+		// Check that the deployment managing the apiserver pods has at last one available replica
+		deploy, err := deployClient.Get(resourceName, metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			// No available replicas if the deployment doesn't exist
+			return
+		}
+		if err != nil {
+			klog.Warningf("Error retrieving the deployment that manages apiserver pods: %v", err)
+			return
+		}
+		if deploy.Status.AvailableReplicas == 0 {
+			eventRecorder.Warning("LegacyDaemonSetCleanup", "the deployment replacing the daemonset does not have available replicas yet")
+			return
+		}
+
+		// Safe to remove legacy daemonset since the deployment has at least one available replica
+		err = dsClient.Delete(resourceName, &metav1.DeleteOptions{})
+		if err != nil && !errors.IsNotFound(err) {
+			klog.Warningf("Failed to delete legacy daemonset: %v", err)
+			return
+		}
+		eventRecorder.Event("LegacyDaemonSetCleanup", "legacy daemonset has been removed")
+	}, time.Minute)
 }

--- a/pkg/operator/workloadcontroller/workload_controller.go
+++ b/pkg/operator/workloadcontroller/workload_controller.go
@@ -88,7 +88,7 @@ func NewWorkloadController(
 	kubeInformersForOpenShiftAPIServerNamespace.Core().V1().ConfigMaps().Informer().AddEventHandler(c.eventHandler())
 	kubeInformersForOpenShiftAPIServerNamespace.Core().V1().ServiceAccounts().Informer().AddEventHandler(c.eventHandler())
 	kubeInformersForOpenShiftAPIServerNamespace.Core().V1().Services().Informer().AddEventHandler(c.eventHandler())
-	kubeInformersForOpenShiftAPIServerNamespace.Apps().V1().DaemonSets().Informer().AddEventHandler(c.eventHandler())
+	kubeInformersForOpenShiftAPIServerNamespace.Apps().V1().Deployments().Informer().AddEventHandler(c.eventHandler())
 	kubeInformersForOpenShiftConfigNamespace.Core().V1().ConfigMaps().Informer().AddEventHandler(c.eventHandler())
 	configInformers.Config().V1().Images().Informer().AddEventHandler(c.eventHandler())
 	apiregistrationInformers.Apiregistration().V1().APIServices().Informer().AddEventHandler(c.eventHandler())

--- a/pkg/operator/workloadcontroller/workload_controller_openshiftapiserver_v311_00.go
+++ b/pkg/operator/workloadcontroller/workload_controller_openshiftapiserver_v311_00.go
@@ -10,6 +10,7 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/ghodss/yaml"
+	"github.com/google/uuid"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -54,11 +55,11 @@ func syncOpenShiftAPIServer_v311_00_to_latest(c OpenShiftAPIServerOperator, orig
 		errors = append(errors, fmt.Errorf("%q: %v", "image-import-ca", err))
 	}
 
-	// our configmaps and secrets are in order, now it is time to create the DS
+	// our configmaps and secrets are in order, now it is time to create the deployment
 	// TODO check basic preconditions here
-	actualDaemonSet, _, err := manageOpenShiftAPIServerDaemonSet_v311_00_to_latest(c.kubeClient, c.kubeClient.AppsV1(), c.eventRecorder, c.targetImagePullSpec, c.operatorImagePullSpec, operatorConfig, operatorConfig.Status.Generations)
+	actualDeployment, _, err := manageOpenShiftAPIServerDeployment_v311_00_to_latest(c.kubeClient, c.kubeClient.AppsV1(), c.eventRecorder, c.targetImagePullSpec, c.operatorImagePullSpec, operatorConfig, operatorConfig.Status.Generations)
 	if err != nil {
-		errors = append(errors, fmt.Errorf("%q: %v", "daemonsets", err))
+		errors = append(errors, fmt.Errorf("%q: %v", "deployments", err))
 	}
 
 	if len(errors) > 0 {
@@ -101,29 +102,29 @@ func syncOpenShiftAPIServer_v311_00_to_latest(c OpenShiftAPIServerOperator, orig
 		)
 	}
 
-	if actualDaemonSet == nil {
-		message := "daemonset/apiserver.openshift-apiserver: could not be retrieved"
+	if actualDeployment == nil {
+		message := "deployment/apiserver.openshift-apiserver: could not be retrieved"
 		errors = append(errors,
 			appendErrors(v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
-				Type:    "APIServerDaemonSetAvailable",
+				Type:    "APIServerDeploymentAvailable",
 				Status:  operatorv1.ConditionFalse,
-				Reason:  "NoDaemon",
+				Reason:  "NoDeployment",
 				Message: message,
 			})))...,
 		)
 		errors = append(errors,
 			appendErrors(v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
-				Type:    "APIServerDaemonSetProgressing",
+				Type:    "APIServerDeploymentProgressing",
 				Status:  operatorv1.ConditionTrue,
-				Reason:  "NoDaemon",
+				Reason:  "NoDeployment",
 				Message: message,
 			})))...,
 		)
 		errors = append(errors,
 			appendErrors(v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
-				Type:    "APIServerDaemonSetDegraded",
+				Type:    "APIServerDeploymentDegraded",
 				Status:  operatorv1.ConditionTrue,
-				Reason:  "NoDaemon",
+				Reason:  "NoDeployment",
 				Message: message,
 			})))...,
 		)
@@ -132,40 +133,40 @@ func syncOpenShiftAPIServer_v311_00_to_latest(c OpenShiftAPIServerOperator, orig
 	}
 
 	// manage status
-	if actualDaemonSet.Status.NumberAvailable == 0 {
+	if actualDeployment.Status.AvailableReplicas == 0 {
 		errors = append(errors,
 			appendErrors(v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
-				Type:    "APIServerDaemonSetAvailable",
+				Type:    "APIServerDeploymentAvailable",
 				Status:  operatorv1.ConditionFalse,
 				Reason:  "NoAPIServerPod",
-				Message: "no openshift-apiserver daemon pods available on any node.",
+				Message: "no openshift-apiserver pods available.",
 			})))...,
 		)
 	} else {
 		errors = append(errors,
 			appendErrors(v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
-				Type:   "APIServerDaemonSetAvailable",
+				Type:   "APIServerDeploymentAvailable",
 				Status: operatorv1.ConditionTrue,
 				Reason: "AsExpected",
 			})))...,
 		)
 	}
 
-	// If the daemonset is up to date and the operatorConfig are up to date, then we are no longer progressing
-	daemonSetAtHighestGeneration := actualDaemonSet.ObjectMeta.Generation == actualDaemonSet.Status.ObservedGeneration
-	if !daemonSetAtHighestGeneration {
+	// If the deployment is up to date and the operatorConfig are up to date, then we are no longer progressing
+	deploymentAtHighestGeneration := actualDeployment.ObjectMeta.Generation == actualDeployment.Status.ObservedGeneration
+	if !deploymentAtHighestGeneration {
 		errors = append(errors,
 			appendErrors(v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
-				Type:    "APIServerDaemonSetProgressing",
+				Type:    "APIServerDeploymentProgressing",
 				Status:  operatorv1.ConditionTrue,
 				Reason:  "NewGeneration",
-				Message: fmt.Sprintf("daemonset/apiserver.openshift-operator: observed generation is %d, desired generation is %d.", actualDaemonSet.Status.ObservedGeneration, actualDaemonSet.ObjectMeta.Generation),
+				Message: fmt.Sprintf("deployment/apiserver.openshift-operator: observed generation is %d, desired generation is %d.", actualDeployment.Status.ObservedGeneration, actualDeployment.ObjectMeta.Generation),
 			})))...,
 		)
 	} else {
 		errors = append(errors,
 			appendErrors(v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
-				Type:   "APIServerDaemonSetProgressing",
+				Type:   "APIServerDeploymentProgressing",
 				Status: operatorv1.ConditionFalse,
 				Reason: "AsExpected",
 			})))...,
@@ -181,38 +182,43 @@ func syncOpenShiftAPIServer_v311_00_to_latest(c OpenShiftAPIServerOperator, orig
 	)
 	errors = append(errors,
 		appendErrors(v1helpers.UpdateStatus(c.operatorClient, func(status *operatorv1.OperatorStatus) error {
-			resourcemerge.SetDaemonSetGeneration(&status.Generations, actualDaemonSet)
+			resourcemerge.SetDeploymentGeneration(&status.Generations, actualDeployment)
 			return nil
 		}))...,
 	)
 
-	daemonSetHasAllPodsAvailable := actualDaemonSet.Status.NumberAvailable == actualDaemonSet.Status.DesiredNumberScheduled
-	if !daemonSetHasAllPodsAvailable {
-		numNonAvailablePods := actualDaemonSet.Status.DesiredNumberScheduled - actualDaemonSet.Status.NumberAvailable
+	desiredReplicas := int32(1)
+	if actualDeployment.Spec.Replicas != nil {
+		desiredReplicas = *(actualDeployment.Spec.Replicas)
+	}
+
+	deploymentHasAllPodsAvailable := actualDeployment.Status.AvailableReplicas == desiredReplicas
+	if !deploymentHasAllPodsAvailable {
+		numNonAvailablePods := desiredReplicas - actualDeployment.Status.AvailableReplicas
 		errors = append(errors,
 			appendErrors(v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
-				Type:    "APIServerDaemonSetDegraded",
+				Type:    "APIServerDeploymentDegraded",
 				Status:  operatorv1.ConditionTrue,
 				Reason:  "UnavailablePod",
-				Message: fmt.Sprintf("%v of %v requested instances are unavailable", numNonAvailablePods, actualDaemonSet.Status.DesiredNumberScheduled),
+				Message: fmt.Sprintf("%v of %v requested instances are unavailable", numNonAvailablePods, desiredReplicas),
 			})))...,
 		)
 	} else {
 		errors = append(errors,
 			appendErrors(v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
-				Type:   "APIServerDaemonSetDegraded",
+				Type:   "APIServerDeploymentDegraded",
 				Status: operatorv1.ConditionFalse,
 				Reason: "AsExpected",
 			})))...,
 		)
 	}
 
-	// if the daemonset is all available and at the expected generation, then update the version to the latest
-	// when we update, the image pull spec should immediately be different, which should immediately cause a daemonset rollout
-	// which should immediately result in a daemonset generation diff, which should cause this block to be skipped until it is ready.
-	daemonSetHasAllPodsUpdated := actualDaemonSet.Status.UpdatedNumberScheduled == actualDaemonSet.Status.DesiredNumberScheduled
+	// if the deployment is all available and at the expected generation, then update the version to the latest
+	// when we update, the image pull spec should immediately be different, which should immediately cause a deployment rollout
+	// which should immediately result in a deployment generation diff, which should cause this block to be skipped until it is ready.
+	deploymentHasAllPodsUpdated := actualDeployment.Status.UpdatedReplicas == desiredReplicas
 	operatorConfigAtHighestGeneration := operatorConfig.Status.ObservedGeneration == operatorConfig.ObjectMeta.Generation
-	if operatorConfigAtHighestGeneration && daemonSetAtHighestGeneration && daemonSetHasAllPodsAvailable && daemonSetHasAllPodsUpdated {
+	if operatorConfigAtHighestGeneration && deploymentAtHighestGeneration && deploymentHasAllPodsAvailable && deploymentHasAllPodsUpdated {
 		c.versionRecorder.SetVersion("openshift-apiserver", c.targetOperandVersion)
 	}
 
@@ -326,16 +332,16 @@ func loglevelToKlog(logLevel operatorv1.LogLevel) string {
 	}
 }
 
-func manageOpenShiftAPIServerDaemonSet_v311_00_to_latest(
+func manageOpenShiftAPIServerDeployment_v311_00_to_latest(
 	kubeClient kubernetes.Interface,
-	client appsclientv1.DaemonSetsGetter,
+	client appsclientv1.DeploymentsGetter,
 	recorder events.Recorder,
 	imagePullSpec string,
 	operatorImagePullSpec string,
 	operatorConfig *operatorv1.OpenShiftAPIServer,
 	generationStatus []operatorv1.GenerationStatus,
-) (*appsv1.DaemonSet, bool, error) {
-	tmpl := v311_00_assets.MustAsset("v3.11.0/openshift-apiserver/ds.yaml")
+) (*appsv1.Deployment, bool, error) {
+	tmpl := v311_00_assets.MustAsset("v3.11.0/openshift-apiserver/deploy.yaml")
 
 	r := strings.NewReplacer(
 		"${IMAGE}", imagePullSpec,
@@ -350,10 +356,10 @@ func manageOpenShiftAPIServerDaemonSet_v311_00_to_latest(
 		return nil, false, fmt.Errorf("invalid template reference %q", string(match))
 	}
 
-	required := resourceread.ReadDaemonSetV1OrDie(tmpl)
+	required := resourceread.ReadDeploymentV1OrDie(tmpl)
 
 	// we set this so that when the requested image pull spec changes, we always have a diff.  Remember that we don't directly
-	// diff any fields on the daemonset because they can be rewritten by admission and we don't want to constantly be fighting
+	// diff any fields on the deployment because they can be rewritten by admission and we don't want to constantly be fighting
 	// against admission or defaults.  That was a problem with original versions of apply.
 	if required.Annotations == nil {
 		required.Annotations = map[string]string{}
@@ -363,6 +369,7 @@ func manageOpenShiftAPIServerDaemonSet_v311_00_to_latest(
 
 	required.Labels["revision"] = strconv.Itoa(int(operatorConfig.Status.LatestAvailableRevision))
 	required.Spec.Template.Labels["revision"] = strconv.Itoa(int(operatorConfig.Status.LatestAvailableRevision))
+	required.Spec.Template.Labels["previousGeneration"] = strconv.Itoa(int(operatorConfig.Status.LatestAvailableRevision))
 
 	var observedConfig map[string]interface{}
 	if err := yaml.Unmarshal(operatorConfig.Spec.ObservedConfig.Raw, &observedConfig); err != nil {
@@ -378,7 +385,7 @@ func manageOpenShiftAPIServerDaemonSet_v311_00_to_latest(
 		required.Spec.Template.Spec.Containers[i].Env = append(container.Env, proxyEnvVars...)
 	}
 
-	// we watch some resources so that our daemonset will redeploy without explicitly and carefully ordered resource creation
+	// we watch some resources so that our deployment will redeploy without explicitly and carefully ordered resource creation
 	inputHashes, err := resourcehash.MultipleObjectHashStringMapForObjectReferences(
 		kubeClient,
 		resourcehash.NewObjectRef().ForConfigMap().InNamespace(operatorclient.TargetNamespace).Named("config"),
@@ -400,7 +407,12 @@ func manageOpenShiftAPIServerDaemonSet_v311_00_to_latest(
 		required.Spec.Template.Annotations[annotationKey] = v
 	}
 
-	return resourceapply.ApplyDaemonSet(client, recorder, required, resourcemerge.ExpectedDaemonSetGeneration(required, generationStatus), false)
+	err = ensureAtMostOnePodPerNode(&required.Spec)
+	if err != nil {
+		return nil, false, fmt.Errorf("unable to ensure at most one pod per node: %v", err)
+	}
+
+	return resourceapply.ApplyDeployment(client, recorder, required, resourcemerge.ExpectedDeploymentGeneration(required, generationStatus), false)
 }
 
 var openshiftScheme = runtime.NewScheme()
@@ -453,4 +465,53 @@ func proxyMapToEnvVars(proxyConfig map[string]string) []corev1.EnvVar {
 	// sort the env vars to prevent update hotloops
 	sort.Slice(envVars, func(i, j int) bool { return envVars[i].Name < envVars[j].Name })
 	return envVars
+}
+
+// ensureAtMostOnePodPerNode updates the deployment spec to prevent more than
+// one pod of a given replicaset from landing on a node. It accomplishes this
+// by adding a uuid as a label on the template and updates the pod
+// anti-affinity term to include that label. Since the deployment is only
+// written (via ApplyDeployment) when the metadata differs or the generations
+// don't match, the uuid should only be updated in the API when a new
+// replicaset is created.
+func ensureAtMostOnePodPerNode(spec *appsv1.DeploymentSpec) error {
+	uuidKey := "anti-affinity-uuid"
+	uuidValue := uuid.New().String()
+
+	// Label the pod template with the template hash
+	spec.Template.Labels[uuidKey] = uuidValue
+
+	// Ensure that match labels are defined
+	if spec.Selector == nil {
+		return fmt.Errorf("deployment is missing spec.selector")
+	}
+	if len(spec.Selector.MatchLabels) == 0 {
+		return fmt.Errorf("deployment is missing spec.selector.matchLabels")
+	}
+
+	// Ensure anti-affinity selects on the uuid
+	antiAffinityMatchLabels := map[string]string{
+		uuidKey: uuidValue,
+	}
+	// Ensure anti-affinity selects on the same labels as the deployment
+	for key, value := range spec.Selector.MatchLabels {
+		antiAffinityMatchLabels[key] = value
+	}
+
+	// Add an anti-affinity rule to the pod template that precludes more than
+	// one pod for a uuid from being scheduled to a node.
+	spec.Template.Spec.Affinity = &corev1.Affinity{
+		PodAntiAffinity: &corev1.PodAntiAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+				{
+					TopologyKey: "kubernetes.io/hostname",
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: antiAffinityMatchLabels,
+					},
+				},
+			},
+		},
+	}
+
+	return nil
 }

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -40,12 +40,12 @@ func TestRedeployOnConfigChange(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ds, err := kubeClient.AppsV1().DaemonSets(operatorclient.TargetNamespace).Get("apiserver", metav1.GetOptions{})
+	deployment, err := kubeClient.AppsV1().Deployments(operatorclient.TargetNamespace).Get("apiserver", metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	prevGeneration := ds.Generation
+	prevGeneration := deployment.Generation
 
 	configCMClient := kubeClient.CoreV1().ConfigMaps(operatorclient.GlobalUserSpecifiedConfigNamespace)
 
@@ -61,12 +61,12 @@ func TestRedeployOnConfigChange(t *testing.T) {
 	}
 
 	err = wait.PollImmediate(1*time.Second, 2*time.Minute, func() (done bool, err error) {
-		ds, err := kubeClient.AppsV1().DaemonSets(operatorclient.TargetNamespace).Get("apiserver", metav1.GetOptions{})
+		deployment, err := kubeClient.AppsV1().Deployments(operatorclient.TargetNamespace).Get("apiserver", metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
 
-		if ds.Generation == prevGeneration {
+		if deployment.Generation == prevGeneration {
 			return false, nil
 		}
 


### PR DESCRIPTION
The switch from using a daemonset to using a deployment is intended to improve reliability during upgrade.

bz: https://bugzilla.redhat.com/show_bug.cgi?id=1804717

/cc @sttts @deads2k 