### PR TITLE
Bug 1806671: openshift-apiserver should never use the bootstrap etcd member

### DIFF
--- a/pkg/operator/configobservation/etcdobserver/observe_etcd_test.go
+++ b/pkg/operator/configobservation/etcdobserver/observe_etcd_test.go
@@ -28,8 +28,7 @@ func TestObserveStorageURLs(t *testing.T) {
 		{
 			name:          "NoEtcdHosts",
 			currentConfig: observedConfig(withStorageURL("https://previous.url:2379")),
-			expected:      observedConfig(withStorageURL("https://previous.url:2379")),
-			expectErrors:  true,
+			expected:      observedConfig(),
 		},
 		{
 			name:          "ValidIPv4",
@@ -164,7 +163,7 @@ func withStorageURL(url string) func(map[string]interface{}) {
 func endpoints(configs ...func(endpoints *v1.Endpoints)) *v1.Endpoints {
 	endpoints := &v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "host-etcd",
+			Name:      "host-etcd-2",
 			Namespace: "openshift-etcd",
 			Annotations: map[string]string{
 				"alpha.installer.openshift.io/dns-suffix": clusterFQDN,

--- a/pkg/operator/operatorclient/interfaces.go
+++ b/pkg/operator/operatorclient/interfaces.go
@@ -5,6 +5,4 @@ const (
 	GlobalMachineSpecifiedConfigNamespace = "openshift-config-managed"
 	OperatorNamespace                     = "openshift-apiserver-operator"
 	TargetNamespace                       = "openshift-apiserver"
-	EtcdEndpointNamespace                 = "openshift-etcd"
-	EtcdEndpointName                      = "host-etcd"
 )


### PR DESCRIPTION
oas should never use the bootstrap etcd member.
Switch to the new `host-etcd-2`, which never contains the etcd bootstrap member, endpoints resource to determine the storage urls.