### PR TITLE
Bug 1806918: remove run-level=1 from openshift-apiserver NS

### DIFF
--- a/bindata/v3.11.0/openshift-apiserver/ns.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/ns.yaml
@@ -5,5 +5,5 @@ metadata:
     openshift.io/node-selector: ""
   name: openshift-apiserver
   labels:
-    openshift.io/run-level: "1"
+    openshift.io/run-level-: "" # remove the label if previously set
     openshift.io/cluster-monitoring: "true"

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -383,7 +383,7 @@ metadata:
     openshift.io/node-selector: ""
   name: openshift-apiserver
   labels:
-    openshift.io/run-level: "1"
+    openshift.io/run-level-: "" # remove the label if previously set
     openshift.io/cluster-monitoring: "true"
 `)
 


### PR DESCRIPTION
The apiserver DS runs with privileged SCC anyway.