### PR TITLE
bug 1804717: Cleanup switch to managing openshift-apiserver pods with a deployment

### DIFF
--- a/bindata/v3.11.0/openshift-apiserver/deploy.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/deploy.yaml
@@ -7,7 +7,7 @@ metadata:
     app: openshift-apiserver
     apiserver: "true"
 spec:
-  replicas: 3
+  # The number of replicas will be set in code to the number of master nodes.
   selector:
     matchLabels:
       # Need to vary the app label from that used by the legacy

--- a/pkg/operator/apiservicecontroller/apiservice_controller.go
+++ b/pkg/operator/apiservicecontroller/apiservice_controller.go
@@ -220,20 +220,20 @@ func (c *APIServiceController) runWorker() {
 }
 
 func (c *APIServiceController) processNextWorkItem() bool {
-	dsKey, quit := c.queue.Get()
+	key, quit := c.queue.Get()
 	if quit {
 		return false
 	}
-	defer c.queue.Done(dsKey)
+	defer c.queue.Done(key)
 
 	err := c.sync()
 	if err == nil {
-		c.queue.Forget(dsKey)
+		c.queue.Forget(key)
 		return true
 	}
 
-	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
-	c.queue.AddRateLimited(dsKey)
+	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", key, err))
+	c.queue.AddRateLimited(key)
 
 	return true
 }

--- a/pkg/operator/deploynodeprovider.go
+++ b/pkg/operator/deploynodeprovider.go
@@ -23,7 +23,7 @@ var (
 )
 
 func (p DeploymentNodeProvider) MasterNodeNames() ([]string, error) {
-	ds, err := p.TargetNamespaceDeploymentInformer.Lister().Deployments(operatorclient.TargetNamespace).Get("apiserver")
+	deploy, err := p.TargetNamespaceDeploymentInformer.Lister().Deployments(operatorclient.TargetNamespace).Get("apiserver")
 	if err != nil && errors.IsNotFound(err) {
 		return nil, nil
 	}
@@ -31,7 +31,7 @@ func (p DeploymentNodeProvider) MasterNodeNames() ([]string, error) {
 		return nil, err
 	}
 
-	nodes, err := p.NodeInformer.Lister().List(labels.SelectorFromSet(ds.Spec.Template.Spec.NodeSelector))
+	nodes, err := p.NodeInformer.Lister().List(labels.SelectorFromSet(deploy.Spec.Template.Spec.NodeSelector))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operator/prunecontroller/prune_controller.go
+++ b/pkg/operator/prunecontroller/prune_controller.go
@@ -237,20 +237,20 @@ func (c *PruneController) runWorker() {
 }
 
 func (c *PruneController) processNextWorkItem() bool {
-	dsKey, quit := c.queue.Get()
+	key, quit := c.queue.Get()
 	if quit {
 		return false
 	}
-	defer c.queue.Done(dsKey)
+	defer c.queue.Done(key)
 
 	err := c.sync()
 	if err == nil {
-		c.queue.Forget(dsKey)
+		c.queue.Forget(key)
 		return true
 	}
 
-	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
-	c.queue.AddRateLimited(dsKey)
+	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", key, err))
+	c.queue.AddRateLimited(key)
 
 	return true
 }

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -136,6 +136,8 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 	}
 	versionRecorder.SetVersion("operator", os.Getenv("OPERATOR_IMAGE_VERSION"))
 
+	nodeInformer := kubeInformersForNamespaces.InformersFor("").Core().V1().Nodes()
+
 	workloadController := workloadcontroller.NewWorkloadController(
 		os.Getenv("IMAGE"), os.Getenv("OPERATOR_IMAGE_VERSION"), os.Getenv("OPERATOR_IMAGE"),
 		operatorClient,
@@ -146,6 +148,7 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		kubeInformersForNamespaces.InformersFor(operatorclient.GlobalUserSpecifiedConfigNamespace),
 		apiregistrationInformers,
 		configInformers,
+		nodeInformer,
 		operatorConfigClient.OperatorV1(),
 		configClient.ConfigV1(),
 		kubeClient,
@@ -209,7 +212,7 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 
 	nodeProvider := DeploymentNodeProvider{
 		TargetNamespaceDeploymentInformer: kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Apps().V1().Deployments(),
-		NodeInformer:                      kubeInformersForNamespaces.InformersFor("").Core().V1().Nodes(),
+		NodeInformer:                      nodeInformer,
 	}
 
 	deployer, err := encryptiondeployer.NewRevisionLabelPodDeployer("revision", operatorclient.TargetNamespace, kubeInformersForNamespaces, resourceSyncController, kubeClient.CoreV1(), kubeClient.CoreV1(), nodeProvider)

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -182,7 +182,7 @@ metadata:
     app: openshift-apiserver
     apiserver: "true"
 spec:
-  replicas: 3
+  # The number of replicas will be set in code to the number of master nodes.
   selector:
     matchLabels:
       # Need to vary the app label from that used by the legacy

--- a/pkg/operator/workloadcontroller/workload_controller.go
+++ b/pkg/operator/workloadcontroller/workload_controller.go
@@ -14,10 +14,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	kubeinformers "k8s.io/client-go/informers"
+	corev1informers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
@@ -38,6 +40,8 @@ const (
 	workQueueKey      = "key"
 )
 
+type nodeCountFunc func(nodeSelector map[string]string) (*int32, error)
+
 type OpenShiftAPIServerOperator struct {
 	targetImagePullSpec, targetOperandVersion, operatorImagePullSpec string
 
@@ -46,7 +50,12 @@ type OpenShiftAPIServerOperator struct {
 	operatorConfigClient  operatorv1client.OpenShiftAPIServersGetter
 	openshiftConfigClient openshiftconfigclientv1.ConfigV1Interface
 	kubeClient            kubernetes.Interface
+	nodeInformer          corev1informers.NodeInformer
 	eventRecorder         events.Recorder
+
+	// Function to return count of nodes is a variable to support
+	// replacement in unit tests.
+	countNodes nodeCountFunc
 
 	// queue only ever has one item, but it has nice error handling backoff/retry semantics
 	queue workqueue.RateLimitingInterface
@@ -65,6 +74,7 @@ func NewWorkloadController(
 	kubeInformersForOpenShiftConfigNamespace kubeinformers.SharedInformerFactory,
 	apiregistrationInformers apiregistrationinformers.SharedInformerFactory,
 	configInformers configinformers.SharedInformerFactory,
+	nodeInformer corev1informers.NodeInformer,
 	operatorConfigClient operatorv1client.OpenShiftAPIServersGetter,
 	openshiftConfigClient openshiftconfigclientv1.ConfigV1Interface,
 	kubeClient kubernetes.Interface,
@@ -80,10 +90,13 @@ func NewWorkloadController(
 		operatorConfigClient:  operatorConfigClient,
 		openshiftConfigClient: openshiftConfigClient,
 		kubeClient:            kubeClient,
+		nodeInformer:          nodeInformer,
 		eventRecorder:         eventRecorder.WithComponentSuffix("workload-controller"),
 
 		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "OpenShiftAPIServerOperator"),
 	}
+
+	c.countNodes = c.countNodesImpl
 
 	operatorConfigInformer.Informer().AddEventHandler(c.eventHandler())
 	kubeInformersForEtcdNamespace.Core().V1().ConfigMaps().Informer().AddEventHandler(c.eventHandler())
@@ -256,4 +269,18 @@ func (c *OpenShiftAPIServerOperator) namespaceEventHandler() cache.ResourceEvent
 			}
 		},
 	}
+}
+
+// countNodesImpl returns the number of nodes that match the given
+// selector. This supports determining the number of master nodes to
+// allow setting the deployment replica count to match. It is not
+// intended to be called directly and instead should be called via
+// countNodes to allow replacement in testing.
+func (c *OpenShiftAPIServerOperator) countNodesImpl(nodeSelector map[string]string) (*int32, error) {
+	nodes, err := c.nodeInformer.Lister().List(labels.SelectorFromSet(nodeSelector))
+	if err != nil {
+		return nil, err
+	}
+	replicas := int32(len(nodes))
+	return &replicas, nil
 }

--- a/pkg/operator/workloadcontroller/workload_controller.go
+++ b/pkg/operator/workloadcontroller/workload_controller.go
@@ -187,20 +187,20 @@ func (c *OpenShiftAPIServerOperator) runWorker() {
 }
 
 func (c *OpenShiftAPIServerOperator) processNextWorkItem() bool {
-	dsKey, quit := c.queue.Get()
+	key, quit := c.queue.Get()
 	if quit {
 		return false
 	}
-	defer c.queue.Done(dsKey)
+	defer c.queue.Done(key)
 
 	err := c.sync()
 	if err == nil {
-		c.queue.Forget(dsKey)
+		c.queue.Forget(key)
 		return true
 	}
 
-	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
-	c.queue.AddRateLimited(dsKey)
+	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", key, err))
+	c.queue.AddRateLimited(key)
 
 	return true
 }

--- a/pkg/operator/workloadcontroller/workload_controller_openshiftapiserver_v311_00.go
+++ b/pkg/operator/workloadcontroller/workload_controller_openshiftapiserver_v311_00.go
@@ -192,7 +192,9 @@ func syncOpenShiftAPIServer_v311_00_to_latest(c OpenShiftAPIServerOperator, orig
 		desiredReplicas = *(actualDeployment.Spec.Replicas)
 	}
 
-	deploymentHasAllPodsAvailable := actualDeployment.Status.AvailableReplicas == desiredReplicas
+	// During a rollout with default maxSurge (25%) will allow the available
+	// replicas to temporarily exceed the desired replica count.
+	deploymentHasAllPodsAvailable := actualDeployment.Status.AvailableReplicas >= desiredReplicas
 	if !deploymentHasAllPodsAvailable {
 		numNonAvailablePods := desiredReplicas - actualDeployment.Status.AvailableReplicas
 		errors = append(errors,
@@ -369,7 +371,6 @@ func manageOpenShiftAPIServerDeployment_v311_00_to_latest(
 
 	required.Labels["revision"] = strconv.Itoa(int(operatorConfig.Status.LatestAvailableRevision))
 	required.Spec.Template.Labels["revision"] = strconv.Itoa(int(operatorConfig.Status.LatestAvailableRevision))
-	required.Spec.Template.Labels["previousGeneration"] = strconv.Itoa(int(operatorConfig.Status.LatestAvailableRevision))
 
 	var observedConfig map[string]interface{}
 	if err := yaml.Unmarshal(operatorConfig.Spec.ObservedConfig.Raw, &observedConfig); err != nil {

--- a/pkg/operator/workloadcontroller/workload_controller_openshiftapiserver_v311_00_test.go
+++ b/pkg/operator/workloadcontroller/workload_controller_openshiftapiserver_v311_00_test.go
@@ -26,6 +26,11 @@ import (
 	kubetesting "k8s.io/client-go/testing"
 )
 
+func fakeCountNodes(_ map[string]string) (*int32, error) {
+	masterNodeCount := int32(3)
+	return &masterNodeCount, nil
+}
+
 func TestAPIServerDeploymentProgressingCondition(t *testing.T) {
 	testCases := []struct {
 		name                         string
@@ -102,6 +107,7 @@ func TestAPIServerDeploymentProgressingCondition(t *testing.T) {
 				operatorConfigClient:  apiServiceOperatorClient.OperatorV1(),
 				openshiftConfigClient: openshiftConfigClient.ConfigV1(),
 				versionRecorder:       status.NewVersionGetter(),
+				countNodes:            fakeCountNodes,
 			}
 
 			_ = syncOpenShiftAPIServer_v311_00_to_latest(operator, operatorConfig)
@@ -198,6 +204,7 @@ func TestOperatorConfigProgressingCondition(t *testing.T) {
 				operatorConfigClient:  apiServiceOperatorClient.OperatorV1(),
 				openshiftConfigClient: openshiftConfigClient.ConfigV1(),
 				versionRecorder:       status.NewVersionGetter(),
+				countNodes:            fakeCountNodes,
 			}
 
 			_ = syncOpenShiftAPIServer_v311_00_to_latest(operator, operatorConfig)
@@ -314,6 +321,7 @@ func TestAvailableStatus(t *testing.T) {
 				operatorConfigClient:  apiServiceOperatorClient.OperatorV1(),
 				openshiftConfigClient: openshiftConfigClient.ConfigV1(),
 				versionRecorder:       status.NewVersionGetter(),
+				countNodes:            fakeCountNodes,
 			}
 
 			_ = syncOpenShiftAPIServer_v311_00_to_latest(operator, operatorConfig)


### PR DESCRIPTION
This PR addresses comments and otherwise unresolved issues from #313 

- Sets the replica count according to the number of master nodes
- Ensures the operator doesn't report degraded if the number of available nodes exceeds the desired replica count (a likely scenario during rollout)
- Removes the unintentionally applied `previousGeneration` label from the deployment
- Updates previously unnoticed daemonset-derived variable names.

cc: @deads2k @sttts @tnozicka 