### PR TITLE
Bug 1808568: Fix rollout strategy to never run more than one pod per node

### DIFF
--- a/bindata/v3.11.0/openshift-apiserver/deploy.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/deploy.yaml
@@ -8,6 +8,16 @@ metadata:
     apiserver: "true"
 spec:
   # The number of replicas will be set in code to the number of master nodes.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      # To ensure that only one pod at a time writes to the node's
+      # audit log, require the update strategy to proceed a node at a
+      # time. Only when a master node has its existing
+      # openshift-apiserver pod stopped will a new one be allowed to
+      # start.
+      maxUnavailable: 1
+      maxSurge: 0
   selector:
     matchLabels:
       # Need to vary the app label from that used by the legacy
@@ -143,5 +153,12 @@ spec:
         operator: "Exists"
         effect: "NoExecute"
         tolerationSeconds: 120
-      # Anti-affinity is configured in code due to the need to scope
-      # selection to the computed pod template.
+      affinity:
+        podAntiAffinity:
+          # Ensure that at most one apiserver pod will be scheduled on a node.
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: "kubernetes.io/hostname"
+            labelSelector:
+              matchLabels:
+                app: "openshift-apiserver-a"
+                apiserver: "true"


### PR DESCRIPTION
Update the deployment rollout strategy to never allow more than one pod to run at a time on a given master node. This change removes the need to set an anti-affinity uuid label since the previous replica set's pod must be turned down before a new one can be scheduled.

The previous rollout strategy allowed more than one pod per node to run on a given master node during rollout. This was a break from the rollout strategy used by the daemonset controller, where each node had its pod turned down before another could start. The daemonset behavior must be maintained to ensure coherent audit logs.