### PR TITLE
Bug 1812583: Normalize CPU requests on masters

### DIFF
--- a/bindata/v3.11.0/openshift-apiserver/deploy.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/deploy.yaml
@@ -68,7 +68,7 @@ spec:
         resources:
           requests:
             memory: 200Mi
-            cpu: 150m
+            cpu: 100m
         # we need to set this to privileged to be able to write audit to /var/log/openshift-apiserver
         securityContext:
           privileged: true

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -243,7 +243,7 @@ spec:
         resources:
           requests:
             memory: 200Mi
-            cpu: 150m
+            cpu: 100m
         # we need to set this to privileged to be able to write audit to /var/log/openshift-apiserver
         securityContext:
           privileged: true


### PR DESCRIPTION
The openshift-apiserver uses approximately 10% of master CPU in a
reasonable medium sized workload. Given a 1 core per master baseline
(since CPU is compressible and shared), assign the openshift-apiserver
roughly 10% of that core on each master.

4.4 bug is 1812709