### PR TITLE
Bug 1814618: storage urls observer: prevent event/log spam

### DIFF
--- a/pkg/operator/configobservation/etcdobserver/observe_etcd.go
+++ b/pkg/operator/configobservation/etcdobserver/observe_etcd.go
@@ -87,7 +87,7 @@ func ObserveStorageURLs(genericListers configobserver.Listers, recorder events.R
 		errs = append(errs, err)
 	}
 
-	if !reflect.DeepEqual(currentEtcdURLs, etcdURLs) {
+	if !reflect.DeepEqual(currentEtcdURLs, []string(etcdURLs)) {
 		recorder.Eventf("ObserveStorageUpdated", "Updated storage urls to %s", strings.Join(etcdURLs, ","))
 	}
 


### PR DESCRIPTION
DeepEqual fails on type comparison resulting in spamming update events