### PR TITLE
OAuthAPIServerController

### DIFF
--- a/pkg/operator/oauthapiencryptioncontroller/oauthapiencryptioncontroller.go
+++ b/pkg/operator/oauthapiencryptioncontroller/oauthapiencryptioncontroller.go
@@ -1,0 +1,133 @@
+package oauthapiencryptioncontroller
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/cluster-openshift-apiserver-operator/pkg/operator/operatorclient"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/encryption/encryptionconfig"
+	encryptionsecret "github.com/openshift/library-go/pkg/operator/encryption/secrets"
+	encryptionstate "github.com/openshift/library-go/pkg/operator/encryption/state"
+	"github.com/openshift/library-go/pkg/operator/events"
+	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+)
+
+const (
+	encryptionConfigManagedBy      = "encryption.apiserver.operator.openshift.io/managed-by"
+	encryptionConfigManagedByValue = `WARNING: DO NOT REMOVE.
+This annotation indicates that OAS-O manages this secret.`
+)
+
+type oauthAPIServerController struct {
+	targetNamespace               string
+	oauthAPIServerTargetNamespace string
+
+	secretLister corev1listers.SecretNamespaceLister
+	secretClient corev1client.SecretInterface
+}
+
+// New creates OAuthAPIServerController that will manage encryption-config-openshift-oauth-apiserver in openshift-config-managed namespace as described in https://github.com/openshift/enhancements/blob/master/enhancements/etcd/etcd-encryption-for-separate-oauth-apis.md
+// Note that this code will be removed in the future release (4.6)
+func New(
+	name string,
+	targetNamespace string,
+	oauthAPIServerTargetNamespace string,
+	secretClient corev1client.SecretsGetter,
+	kubeInformersForNamespaces operatorv1helpers.KubeInformersForNamespaces,
+	eventRecorder events.Recorder) factory.Controller {
+
+	controllerFactory := factory.New()
+	target := &oauthAPIServerController{
+		targetNamespace:               targetNamespace,
+		oauthAPIServerTargetNamespace: oauthAPIServerTargetNamespace,
+		secretLister:                  kubeInformersForNamespaces.InformersFor(operatorclient.GlobalMachineSpecifiedConfigNamespace).Core().V1().Secrets().Lister().Secrets(operatorclient.GlobalMachineSpecifiedConfigNamespace),
+		secretClient:                  secretClient.Secrets(operatorclient.GlobalMachineSpecifiedConfigNamespace),
+	}
+
+	controllerFactory.WithSync(target.sync)
+	controllerFactory.WithInformers(kubeInformersForNamespaces.InformersFor(operatorclient.GlobalMachineSpecifiedConfigNamespace).Core().V1().Secrets().Informer())
+	return controllerFactory.ToController(name, eventRecorder.WithComponentSuffix("oauth-apiserver-encryption-cfg-sync-controller"))
+}
+
+// sync starts managing oauth-apiserver encryption config (encryption-config-openshift-oauth-apiserver in openshift-config-managed namespace) as described in https://github.com/openshift/enhancements/blob/master/enhancements/etcd/etcd-encryption-for-separate-oauth-apis.md
+//
+// case 1: if the secret doesn't exist and encryption is on then:
+//         - it will add the secret with the annotation (must be atomic operation) because CAO will start managing its own config iff the secret exist without the annotation
+//
+// case 2: if the secret exists and it is annotated
+//         - it will simply start synchronisation
+//
+// case 3: no-op: when the secret exits but it doesn't have the annotation - that means it was created by CAO in 4.6 and this is downgrade
+// case 4: no-op: when the secret doesn't exist and encryption is off
+//
+// drawbacks:
+// - it will not recover when the annotation was manually removed by a user,
+//   to recover we would have to put a value in the annotation instead and coordinate OAS-A and CAO but then we would have to remember to add it in CAO (4.6) as well
+func (c *oauthAPIServerController) sync(ctx context.Context, controllerContext factory.SyncContext) error {
+	openshiftAPIServerEncryptionCfg, err := c.secretLister.Get(fmt.Sprintf("%s-%s", encryptionconfig.EncryptionConfSecretName, c.targetNamespace))
+	if apierrors.IsNotFound(err) {
+		return nil // case 4: encryption off
+	}
+	if err != nil {
+		return err
+	}
+
+	oauthAPIServerEncryptionCfgName := fmt.Sprintf("%s-%s", encryptionconfig.EncryptionConfSecretName, c.oauthAPIServerTargetNamespace)
+	oauthAPIServerEncryptionCfg, err := c.secretLister.Get(oauthAPIServerEncryptionCfgName)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	if apierrors.IsNotFound(err) {
+		// case 1: create with annotation
+		if _, exists := openshiftAPIServerEncryptionCfg.Data[encryptionconfig.EncryptionConfSecretKey]; !exists {
+			return fmt.Errorf("%s/%s doesn't contain the required key %q", openshiftAPIServerEncryptionCfg.Namespace, openshiftAPIServerEncryptionCfg.Name, encryptionconfig.EncryptionConfSecretKey)
+		}
+		encryptionCfg := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      oauthAPIServerEncryptionCfgName,
+				Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace,
+				Annotations: map[string]string{
+					encryptionConfigManagedBy:                encryptionConfigManagedByValue,
+					encryptionstate.KubernetesDescriptionKey: encryptionstate.KubernetesDescriptionScaryValue,
+				},
+				Finalizers: []string{encryptionsecret.EncryptionSecretFinalizer},
+			},
+			Data: map[string][]byte{},
+		}
+		encryptionCfg.Data[encryptionconfig.EncryptionConfSecretKey] = openshiftAPIServerEncryptionCfg.Data[encryptionconfig.EncryptionConfSecretKey]
+
+		_, err := c.secretClient.Create(ctx, encryptionCfg, metav1.CreateOptions{})
+		if err != nil {
+			return err
+		}
+		controllerContext.Recorder().Eventf("SecretCreated", "Created %s in %s namespace because it was missing", oauthAPIServerEncryptionCfgName, operatorclient.GlobalMachineSpecifiedConfigNamespace)
+		return nil
+	}
+	if _, exist := oauthAPIServerEncryptionCfg.Annotations[encryptionConfigManagedBy]; exist {
+		// case 2: exists and it is annotated
+		oauthEncryptionCfgData := oauthAPIServerEncryptionCfg.Data[encryptionconfig.EncryptionConfSecretKey]
+		oasEncryptionCfgData := openshiftAPIServerEncryptionCfg.Data[encryptionconfig.EncryptionConfSecretKey]
+		if !equality.Semantic.DeepEqual(oauthEncryptionCfgData, oasEncryptionCfgData) {
+			encryptionCfg := oauthAPIServerEncryptionCfg.DeepCopy()
+			encryptionCfg.Data[encryptionconfig.EncryptionConfSecretName] = oasEncryptionCfgData
+			_, err := c.secretClient.Update(ctx, encryptionCfg, metav1.UpdateOptions{})
+			if err != nil {
+				return err
+			}
+			controllerContext.Recorder().Eventf("SecretUpdated", "Updates %s in %s namespace because it was out of date with %s ", oauthAPIServerEncryptionCfgName, operatorclient.GlobalMachineSpecifiedConfigNamespace, openshiftAPIServerEncryptionCfg.Name)
+			return nil
+		}
+		return nil
+	}
+
+	// case 3: no-op the secret is managed by CAO
+	return nil
+}

--- a/pkg/operator/oauthapiencryptioncontroller/oauthapiencryptioncontroller_test.go
+++ b/pkg/operator/oauthapiencryptioncontroller/oauthapiencryptioncontroller_test.go
@@ -1,0 +1,242 @@
+package oauthapiencryptioncontroller
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/meta"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/client-go/kubernetes/fake"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	clientgotesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/openshift/cluster-openshift-apiserver-operator/pkg/operator/operatorclient"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/encryption/encryptionconfig"
+	encryptionsecret "github.com/openshift/library-go/pkg/operator/encryption/secrets"
+	encryptionstate "github.com/openshift/library-go/pkg/operator/encryption/state"
+	"github.com/openshift/library-go/pkg/operator/events"
+)
+
+func TestOAuthAPIServerController(t *testing.T) {
+	scenarios := []struct {
+		name           string
+		initialSecrets []*corev1.Secret
+		validateFunc   func(ts *testing.T, actions []clientgotesting.Action)
+
+		expectedActions []string
+		expectedEvents  []string
+	}{
+		{
+			name:            "test case 1 - the secret doesn't exist and encryption is on",
+			initialSecrets:  []*corev1.Secret{defaultSecret(fmt.Sprintf("%s-openshift-apiserver", encryptionconfig.EncryptionConfSecretName))},
+			expectedActions: []string{"create:secrets:openshift-config-managed:encryption-config-oauth-apiserver"},
+			expectedEvents:  []string{"SecretCreated"},
+			validateFunc: func(ts *testing.T, actions []clientgotesting.Action) {
+				wasSecretValidated := false
+				for _, action := range actions {
+					if action.Matches("create", "secrets") {
+						createAction := action.(clientgotesting.UpdateAction)
+						actualSecret := createAction.GetObject().(*corev1.Secret)
+
+						expectedSecret := defaultSecret(fmt.Sprintf("%s-oauth-apiserver", encryptionconfig.EncryptionConfSecretName))
+
+						if !equality.Semantic.DeepEqual(actualSecret, expectedSecret) {
+							ts.Errorf(diff.ObjectDiff(actualSecret, expectedSecret))
+						}
+						wasSecretValidated = true
+						break
+					}
+				}
+				if !wasSecretValidated {
+					ts.Errorf("the secret wasn't validated")
+				}
+			},
+		},
+		{
+			name: "test case 2 - the secret exists, is annotated and it's up to date",
+			initialSecrets: []*corev1.Secret{
+				defaultSecret(fmt.Sprintf("%s-openshift-apiserver", encryptionconfig.EncryptionConfSecretName)),
+				func() *corev1.Secret {
+					s := defaultSecret(fmt.Sprintf("%s-oauth-apiserver", encryptionconfig.EncryptionConfSecretName))
+					s.Annotations["encryption.apiserver.operator.openshift.io/managed-by"] = encryptionConfigManagedByValue
+					return s
+				}(),
+			},
+		},
+		{
+			name: "test case 2 - the secret exists, is annotated but it's out of date",
+			initialSecrets: []*corev1.Secret{
+				func() *corev1.Secret {
+					s := defaultSecret(fmt.Sprintf("%s-openshift-apiserver", encryptionconfig.EncryptionConfSecretName))
+					s.Data["encryption-config"] = []byte{0xAA}
+					return s
+				}(),
+				func() *corev1.Secret {
+					s := defaultSecret(fmt.Sprintf("%s-oauth-apiserver", encryptionconfig.EncryptionConfSecretName))
+					s.Annotations["encryption.apiserver.operator.openshift.io/managed-by"] = encryptionConfigManagedByValue
+					return s
+				}(),
+			},
+			expectedActions: []string{"update:secrets:openshift-config-managed:encryption-config-oauth-apiserver"},
+			expectedEvents:  []string{"SecretUpdated"},
+			validateFunc: func(ts *testing.T, actions []clientgotesting.Action) {
+				wasSecretValidated := false
+				for _, action := range actions {
+					if action.Matches("update", "secrets") {
+						updateAction := action.(clientgotesting.UpdateAction)
+						actualSecret := updateAction.GetObject().(*corev1.Secret)
+
+						expectedSecret := defaultSecret(fmt.Sprintf("%s-oauth-apiserver", encryptionconfig.EncryptionConfSecretName))
+						expectedSecret.Data["encryption-config"] = []byte{0xAA}
+
+						if !equality.Semantic.DeepEqual(actualSecret, expectedSecret) {
+							ts.Errorf(diff.ObjectDiff(actualSecret, expectedSecret))
+						}
+						wasSecretValidated = true
+						break
+					}
+				}
+				if !wasSecretValidated {
+					ts.Errorf("the secret wasn't validated")
+				}
+			},
+		},
+		{
+			name: "test case 3 - no-op the secret was created by CAO in 4.6 and this is downgrade",
+			initialSecrets: []*corev1.Secret{
+				defaultSecret(fmt.Sprintf("%s-openshift-apiserver", encryptionconfig.EncryptionConfSecretName)),
+				defaultSecret(fmt.Sprintf("%s-oauth-apiserver", encryptionconfig.EncryptionConfSecretName)),
+			},
+		},
+		{
+			name: "test case 4 - no-op encryption off",
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			// test data
+			eventRecorder := events.NewInMemoryRecorder("")
+			syncContext := factory.NewSyncContext("", eventRecorder)
+			fakeSecretsIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			for _, secret := range scenario.initialSecrets {
+				fakeSecretsIndexer.Add(secret)
+			}
+			fakeSecretsLister := corev1listers.NewSecretLister(fakeSecretsIndexer)
+
+			rawSecrets := []runtime.Object{}
+			for _, secret := range scenario.initialSecrets {
+				rawSecrets = append(rawSecrets, secret)
+			}
+			fakeKubeClient := fake.NewSimpleClientset(rawSecrets...)
+
+			target := oauthAPIServerController{
+				targetNamespace:               "openshift-apiserver",
+				oauthAPIServerTargetNamespace: "oauth-apiserver",
+				secretLister:                  fakeSecretsLister.Secrets(operatorclient.GlobalMachineSpecifiedConfigNamespace),
+				secretClient:                  fakeKubeClient.CoreV1().Secrets(operatorclient.GlobalMachineSpecifiedConfigNamespace),
+			}
+
+			// act
+			err := target.sync(context.TODO(), syncContext)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// validate
+			if err := validateActionsVerbs(fakeKubeClient.Actions(), scenario.expectedActions); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := validateEventsReason(eventRecorder.Events(), scenario.expectedEvents); err != nil {
+				t.Error(err)
+			}
+			if scenario.validateFunc != nil {
+				scenario.validateFunc(t, fakeKubeClient.Actions())
+			}
+		})
+	}
+}
+
+func defaultSecret(name string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      name,
+			Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace,
+			Annotations: map[string]string{
+				encryptionConfigManagedBy:                encryptionConfigManagedByValue,
+				encryptionstate.KubernetesDescriptionKey: encryptionstate.KubernetesDescriptionScaryValue,
+			},
+			Finalizers: []string{encryptionsecret.EncryptionSecretFinalizer},
+		},
+		Data: map[string][]byte{"encryption-config": {0xFF}},
+	}
+}
+
+func validateActionsVerbs(actualActions []clientgotesting.Action, expectedActions []string) error {
+	if len(actualActions) != len(expectedActions) {
+		return fmt.Errorf("expected to get %d actions but got %d\nexpected=%v \n got=%v", len(expectedActions), len(actualActions), expectedActions, actionStrings(actualActions))
+	}
+	for i, a := range actualActions {
+		if got, expected := actionString(a), expectedActions[i]; got != expected {
+			return fmt.Errorf("at %d got %s, expected %s", i, got, expected)
+		}
+	}
+	return nil
+}
+
+func actionString(a clientgotesting.Action) string {
+	involvedObjectName := ""
+	if updateAction, isUpdateAction := a.(clientgotesting.UpdateAction); isUpdateAction {
+		rawObj := updateAction.GetObject()
+		if objMeta, err := meta.Accessor(rawObj); err == nil {
+			involvedObjectName = objMeta.GetName()
+		}
+	}
+	if getAction, isGetAction := a.(clientgotesting.GetAction); isGetAction {
+		involvedObjectName = getAction.GetName()
+	}
+	action := a.GetVerb() + ":" + a.GetResource().Resource
+	if len(a.GetNamespace()) > 0 {
+		action = action + ":" + a.GetNamespace()
+	}
+	if len(involvedObjectName) > 0 {
+		action = action + ":" + involvedObjectName
+	}
+	return action
+}
+
+func actionStrings(actions []clientgotesting.Action) []string {
+	res := make([]string, 0, len(actions))
+	for _, a := range actions {
+		res = append(res, actionString(a))
+	}
+	return res
+}
+
+func validateEventsReason(actualEvents []*corev1.Event, expectedReasons []string) error {
+	if len(actualEvents) != len(expectedReasons) {
+		return fmt.Errorf("expected to get %d events but got %d\nexpected=%v \n got=%v", len(expectedReasons), len(actualEvents), expectedReasons, eventReasons(actualEvents))
+	}
+	for i, e := range actualEvents {
+		if got, expected := e.Reason, expectedReasons[i]; got != expected {
+			return fmt.Errorf("at %d got %s, expected %s", i, got, expected)
+		}
+	}
+	return nil
+}
+
+func eventReasons(events []*corev1.Event) []string {
+	ret := make([]string, 0, len(events))
+	for _, ev := range events {
+		ret = append(ret, ev.Reason)
+	}
+	return ret
+}


### PR DESCRIPTION
this PR adds `OAuthAPIServerController` that will manage `encryption-config-openshift-oauth-apiserver` as described in https://github.com/openshift/enhancements/blob/master/enhancements/etcd/etcd-encryption-for-separate-oauth-apis.md