### PR TITLE
Bug 1821771: Remove unauthenticated user group from discover cluster role bindings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	go.uber.org/multierr v1.1.1-0.20180122172545-ddea229ff1df // indirect
 	k8s.io/api v0.18.2
 	k8s.io/apimachinery v0.18.2
+	k8s.io/apiserver v0.18.2
 	k8s.io/client-go v0.18.2
 	k8s.io/component-base v0.18.2
 	k8s.io/klog v1.0.0
@@ -27,4 +28,7 @@ require (
 	k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89
 )
 
-replace github.com/kubernetes-sigs/kube-storage-version-migrator => github.com/openshift/kubernetes-kube-storage-version-migrator v0.0.3-0.20200312103335-32e07ea4f8ca
+replace (
+	github.com/kubernetes-sigs/kube-storage-version-migrator => github.com/openshift/kubernetes-kube-storage-version-migrator v0.0.3-0.20200312103335-32e07ea4f8ca
+	github.com/openshift/library-go => github.com/mfojtik/library-go v0.0.0-20200511161500-a4b1c3e3a7a6
+)

--- a/go.sum
+++ b/go.sum
@@ -279,6 +279,8 @@ github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNx
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/mfojtik/library-go v0.0.0-20200511161500-a4b1c3e3a7a6 h1:RDl00jaxal+AHtFOKuEeofz5DjIK+DslhvvA7Ixed+A=
+github.com/mfojtik/library-go v0.0.0-20200511161500-a4b1c3e3a7a6/go.mod h1:2kWwXTkpoQJUN3jZ3QW88EIY1hdRMqxgRs2hheEW/pg=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
@@ -318,8 +320,6 @@ github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0 h1:kMiuiZXH1Gd
 github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0/go.mod h1:uUQ4LClRO+fg5MF/P6QxjMCb1C9f7Oh4RKepftDnEJE=
 github.com/openshift/kubernetes-kube-storage-version-migrator v0.0.3-0.20200312103335-32e07ea4f8ca h1:YNtyJnE53QuEUSjl7L1AARocI021o7cU2bvh4prDtiE=
 github.com/openshift/kubernetes-kube-storage-version-migrator v0.0.3-0.20200312103335-32e07ea4f8ca/go.mod h1:unEnEWccGeVxaXSRsWTjRsNxMqYXmuQjzjcPFQ91H9M=
-github.com/openshift/library-go v0.0.0-20200427130628-9b02543ac833 h1:glEuGTvwkQJXfCzVfosZ3oq73L8QltO6Xyxo1oTf5Ig=
-github.com/openshift/library-go v0.0.0-20200427130628-9b02543ac833/go.mod h1:2kWwXTkpoQJUN3jZ3QW88EIY1hdRMqxgRs2hheEW/pg=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/pkg/operator/rbaccontroller/rbaccontroller.go
+++ b/pkg/operator/rbaccontroller/rbaccontroller.go
@@ -1,0 +1,126 @@
+package rbaccontroller
+
+import (
+	"context"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	listerrbacv1 "k8s.io/client-go/listers/rbac/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+const (
+	// This annotation is set to a value of "true" on RBAC resources created by the openshift-apiserver.
+	openShiftManagedRBACAnnotation = "openshiftapiserver.rbac.authorization.openshift.io/managed"
+)
+
+var (
+	// The named cluster role bindings are created by openshift-apiserver
+	// and in previous releases may have included the unauthenticated subject.
+	clusterRoleBindingNames = sets.NewString("discovery", "basic-users", "system:openshift:discovery",
+		"cluster-status-binding")
+)
+
+// RBACController reconciles RBAC resources created by openshift-apiserver.
+//
+// If openshiftManagedRBACAnnotation is set to "true" for a cluster role binding,
+// RBACController ensures the removal of the unauthenticated subject from its list of subjects.
+//
+// A user can opt-out of this reconciliation by setting the annotation to "false".
+type RBACController struct {
+	eventRecorder            events.Recorder
+	kubeClient               kubernetes.Interface
+	clusterRoleBindingLister listerrbacv1.ClusterRoleBindingLister
+}
+
+func NewRBACController(kubeClient kubernetes.Interface, informerFactory informers.SharedInformerFactory, recorder events.Recorder) factory.Controller {
+	c := &RBACController{
+		kubeClient:               kubeClient,
+		clusterRoleBindingLister: informerFactory.Rbac().V1().ClusterRoleBindings().Lister(),
+		eventRecorder:            recorder,
+	}
+
+	syncCtx := factory.NewSyncContext("RBACController", c.eventRecorder)
+
+	informer := informerFactory.Rbac().V1().ClusterRoleBindings().Informer()
+	informer.AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: hasMatchingAttributes,
+		Handler: cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				key, err := cache.MetaNamespaceKeyFunc(obj)
+				if err == nil {
+					syncCtx.Queue().Add(key)
+				}
+			},
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				key, err := cache.MetaNamespaceKeyFunc(newObj)
+				if err == nil {
+					syncCtx.Queue().Add(key)
+				}
+			},
+		},
+	})
+
+	return factory.New().
+		WithBareInformers(informer).
+		WithSyncContext(syncCtx).
+		WithSync(c.sync).
+		ToController("", nil)
+}
+
+// sync ensures that cluster role bindings created by openshift-apiserver do not have the unauthenticated subject.
+func (c *RBACController) sync(ctx context.Context, syncContext factory.SyncContext) error {
+	_, clusterRoleBindingName, err := cache.SplitMetaNamespaceKey(syncContext.QueueKey())
+	if err != nil {
+		return err
+	}
+
+	clusterRoleBinding, err := c.clusterRoleBindingLister.Get(clusterRoleBindingName)
+	if err != nil {
+		return err
+	}
+
+	updatedCopy := withUnauthenticatedSubjectRemoved(clusterRoleBinding)
+	if updatedCopy == nil {
+		return nil
+	}
+
+	_, err = c.kubeClient.RbacV1().ClusterRoleBindings().Update(ctx, updatedCopy, metav1.UpdateOptions{})
+	return err
+}
+
+// withUnauthenticatedSubjectRemoved returns a new copy of given cluster role binding without unauthenticated user in subjects.
+func withUnauthenticatedSubjectRemoved(clusterRoleBinding *rbacv1.ClusterRoleBinding) *rbacv1.ClusterRoleBinding {
+	for i, subject := range clusterRoleBinding.Subjects {
+		if subject.Name == user.AllUnauthenticated {
+			clusterRoleBindingCopy := clusterRoleBinding.DeepCopy()
+			clusterRoleBindingCopy.Subjects = append(clusterRoleBindingCopy.Subjects[:i],
+				clusterRoleBindingCopy.Subjects[i+1:]...)
+			return clusterRoleBindingCopy
+		}
+	}
+
+	return nil
+}
+
+// hasMatchingAttributes returns true if the obj name equals one of
+// clusterRoleBindingNames and it's RBAC annotation is set to "true".
+func hasMatchingAttributes(obj interface{}) bool {
+	clusterRoleBinding, ok := obj.(*rbacv1.ClusterRoleBinding)
+	if !ok {
+		return false
+	}
+
+	if !clusterRoleBindingNames.Has(clusterRoleBinding.Name) {
+		return false
+	}
+
+	return (clusterRoleBinding.Annotations[openShiftManagedRBACAnnotation] == "true")
+}

--- a/pkg/operator/rbaccontroller/rbaccontroller_test.go
+++ b/pkg/operator/rbaccontroller/rbaccontroller_test.go
@@ -1,0 +1,116 @@
+package rbaccontroller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/openshift/library-go/pkg/operator/events"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestReconcileClusterRoleBinding(t *testing.T) {
+
+	tests := []struct {
+		clusterRoleBinding rbacv1.ClusterRoleBinding
+		expNumOfSubjects   int
+	}{
+		{
+			clusterRoleBinding: rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "basic-users",
+					Annotations: map[string]string{openShiftManagedRBACAnnotation: "true"},
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						Name: user.AllUnauthenticated,
+					},
+					{
+						Name: user.AllAuthenticated,
+					},
+				},
+			},
+			expNumOfSubjects: 1,
+		},
+		{
+			clusterRoleBinding: rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "discovery",
+					Annotations: map[string]string{openShiftManagedRBACAnnotation: "true"},
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						Name: user.AllAuthenticated,
+					},
+				},
+			},
+			expNumOfSubjects: 1,
+		},
+		{
+			clusterRoleBinding: rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "system:openshift:discovery",
+					Annotations: map[string]string{openShiftManagedRBACAnnotation: "false"},
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						Name: user.AllUnauthenticated,
+					},
+				},
+			},
+			expNumOfSubjects: 1,
+		},
+		{
+			clusterRoleBinding: rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster-status-binding",
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						Name: user.AllUnauthenticated,
+					},
+				},
+			},
+			expNumOfSubjects: 1,
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	fakeClient := fake.NewSimpleClientset()
+	for _, obj := range tests {
+		_, err := fakeClient.RbacV1().ClusterRoleBindings().Create(ctx, &obj.clusterRoleBinding, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	informersFactory := informers.NewSharedInformerFactory(fakeClient, 10*time.Minute)
+
+	recorder := events.NewInMemoryRecorder("rbac_controller_test")
+	c := NewRBACController(fakeClient, informersFactory, recorder)
+
+	informersFactory.Start(ctx.Done())
+
+	go c.Run(ctx, 1)
+
+	time.Sleep(1 * time.Second) // allowing for reconcile to happen
+
+	for _, obj := range tests {
+		clusterRoleBinding, err := fakeClient.RbacV1().ClusterRoleBindings().Get(ctx, obj.clusterRoleBinding.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(clusterRoleBinding.Subjects) != obj.expNumOfSubjects {
+			t.Fatalf("%s: mismatch in number of subjects. expected %v observed %v", clusterRoleBinding.Name,
+				obj.expNumOfSubjects, len(clusterRoleBinding.Subjects))
+		}
+	}
+}

--- a/vendor/github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers/status.go
+++ b/vendor/github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers/status.go
@@ -92,6 +92,10 @@ func GetStatusDiff(oldStatus configv1.ClusterOperatorStatus, newStatus configv1.
 		messages = append(messages, fmt.Sprintf("status.extension changed from %q to %q", oldStatus.Extension, newStatus.Extension))
 	}
 
+	if !equality.Semantic.DeepEqual(oldStatus.Versions, newStatus.Versions) {
+		messages = append(messages, fmt.Sprintf("status.versions changed from %q to %q", oldStatus.Versions, newStatus.Versions))
+	}
+
 	if len(messages) == 0 {
 		// ignore errors
 		originalJSON := &bytes.Buffer{}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -228,7 +228,7 @@ github.com/openshift/client-go/operator/informers/externalversions/operator/v1
 github.com/openshift/client-go/operator/informers/externalversions/operator/v1alpha1
 github.com/openshift/client-go/operator/listers/operator/v1
 github.com/openshift/client-go/operator/listers/operator/v1alpha1
-# github.com/openshift/library-go v0.0.0-20200427130628-9b02543ac833
+# github.com/openshift/library-go v0.0.0-20200427130628-9b02543ac833 => github.com/mfojtik/library-go v0.0.0-20200511161500-a4b1c3e3a7a6
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/config/client
 github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers


### PR DESCRIPTION
When a cluster is upgraded from 4.1 - > 4.4, `/` endpoint will be accessible for unauthenticated users. In 4.1 cluster, `/` resource endpoint is used in cluster roles which were given access to unauthenticated user group using `system:openshift:discovery` and `cluster-status-binding` cluster role bindings. After upgrade, as unauthenticated users are still part of those cluster role bindings and their access to the endpoint is not revoked. This PR aims to remove this group of users from cluster role bindings.