### PR TITLE
Bug 1827050: Update to use revised ApplyDeployment

### DIFF
--- a/pkg/operator/workload/workload_openshiftapiserver_v311_00_sync.go
+++ b/pkg/operator/workload/workload_openshiftapiserver_v311_00_sync.go
@@ -388,11 +388,6 @@ func manageOpenShiftAPIServerDeployment_v311_00_to_latest(
 		return nil, false, fmt.Errorf("failed to determine number of master nodes: %v", err)
 	}
 	required.Spec.Replicas = masterNodeCount
-	// Set the replica count as an annotation to ensure that ApplyDeployment
-	// will update the deployment in the API when the replica count
-	// changes. Updates are otherwise skipped if the metadata matches and the
-	// generation is up-to-date.
-	required.Annotations["openshiftapiservers.operator.openshift.io/replicas"] = fmt.Sprintf("%d", *masterNodeCount)
 
 	return resourceapply.ApplyDeployment(client, recorder, required, resourcemerge.ExpectedDeploymentGeneration(required, generationStatus))
 }


### PR DESCRIPTION
The new method hashes the spec of the deployment which removes the setting an annotation containing the replica count.

/cc @deads2k @stlaz 