### PR TITLE
Bug 1828835: remove duplicate migration informer start

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -281,7 +281,6 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 	configInformers.Start(ctx.Done())
 	dynamicInformers.Start(ctx.Done())
 	migrationInformer.Start(ctx.Done())
-	migrationInformer.Start(ctx.Done())
 
 	go configObserver.Run(ctx, 1)
 	go resourceSyncController.Run(ctx, 1)


### PR DESCRIPTION
`migrationInformer.Start(ctx.Done())` is repeated twice and one instance of it can be removed