### PR TITLE
Bug 1832220: operator: add openshift-etcd-operator namespace to related objects

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -170,6 +170,7 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 				{Resource: "namespaces", Name: operatorclient.GlobalMachineSpecifiedConfigNamespace},
 				{Resource: "namespaces", Name: operatorclient.OperatorNamespace},
 				{Resource: "namespaces", Name: operatorclient.TargetNamespace},
+				{Resource: "namespaces", Name: "openshift-etcd-operator"}, // Capture events from etcd operator
 				{Resource: "endpoints", Name: etcdobserver.EtcdEndpointName, Namespace: etcdobserver.EtcdEndpointNamespace},
 			},
 			apiServicesReferences()...,


### PR DESCRIPTION
This will cause insights operator to capture events from etcd operator namespace in case openshift apiserver operator is degraded.