### PR TITLE
Bug 1795163: openshift-apiserver operator not available when used for single node cluster (CRC) 

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -190,7 +190,6 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		configClient.ConfigV1().ClusterOperators(),
 		versionRecorder,
 		kubeInformersForNamespaces,
-		kubeInformersForNamespaces.InformersFor(metav1.NamespaceSystem).Core().V1().ConfigMaps().Informer(),
 		operatorConfigInformers.Operator().V1().OpenShiftAPIServers().Informer(),
 		configInformers.Config().V1().Images().Informer(),
 	).WithStaticResourcesController(


### PR DESCRIPTION
reverts waiting for `requestheader-client-ca-file` in `extension-apiserver-authentication` before rolling out a new version.

it is replaced by https://github.com/openshift/kubernetes-apiserver/pull/10 which essentially shifts the logic to API Servers. From now on a server watches and reacts to changes in the config map in real-time.