### PR TITLE
Bug 1871890: Bump coao to golang 1.14 to match kube

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.13 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.14 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-openshift-apiserver-operator
 COPY . .
 RUN go build ./cmd/cluster-openshift-apiserver-operator


### PR DESCRIPTION
To unblock https://github.com/openshift/cluster-openshift-apiserver-operator/pull/381
/assign @tnozicka 