### PR TITLE
Restrict log permissions

### DIFF
--- a/bindata/v3.11.0/openshift-apiserver/deploy.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/deploy.yaml
@@ -46,7 +46,7 @@ spec:
           terminationMessagePolicy: FallbackToLogsOnError
           image: ${IMAGE}
           imagePullPolicy: IfNotPresent
-          command: ['sh', '-c', 'chmod 0700 /var/log/openshift-apiserver']
+          command: ['sh', '-c', 'chmod 0700 /var/log/openshift-apiserver && touch /var/log/openshift-apiserver/audit.log && chmod 0600 /var/log/openshift-apiserver/*']
           securityContext:
             privileged: true
           volumeMounts:

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -197,7 +197,7 @@ spec:
           terminationMessagePolicy: FallbackToLogsOnError
           image: ${IMAGE}
           imagePullPolicy: IfNotPresent
-          command: ['sh', '-c', 'chmod 0700 /var/log/openshift-apiserver']
+          command: ['sh', '-c', 'chmod 0700 /var/log/openshift-apiserver && touch /var/log/openshift-apiserver/audit.log && chmod 0600 /var/log/openshift-apiserver/*']
           securityContext:
             privileged: true
           volumeMounts:


### PR DESCRIPTION
While the current log directory permissions are restrictive and correct,
the file permissions are too permissive and it raises flags on
evaluations of the deployment. Let's instead change the permissions to
0600 which is more appropriate for these types of logs.

Note that while this is a superficial fix, it is also meant to address upgrades
(on an upgrade scenario, the permissions of old and rotated log files will be
fixed).