### PR TITLE
Bug 1876166: need to be able to disable kube-apiserver connectivity checks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/openshift/api v0.0.0-20200929125329-c3027fc03b92
 	github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7
 	github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5
-	github.com/openshift/library-go v0.0.0-20200930152912-7219e4f70a45
+	github.com/openshift/library-go v0.0.0-20201012194941-89c1c3827d6f
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -394,8 +394,8 @@ github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7 h1:mO
 github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5 h1:E6WhVL5p3rfjtc+o+jVG/29Aclnf3XIF7akxXvadwR0=
 github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5/go.mod h1:5rGmrkQ8DJEUXA+AR3rEjfH+HFyg4/apY9iCQFgvPfE=
-github.com/openshift/library-go v0.0.0-20200930152912-7219e4f70a45 h1:8PqY3OfWd6VdpNZEza8AWefMJJFdoVmkgM/7kSHag1g=
-github.com/openshift/library-go v0.0.0-20200930152912-7219e4f70a45/go.mod h1:NI6xOQGuTnLXeHW8Z2glKSFhF7X+YxlAlqlBMaK0zEM=
+github.com/openshift/library-go v0.0.0-20201012194941-89c1c3827d6f h1:1NLDzISHwTNqBdrcFz3DwfXjoAB3mul4eoMQmMXwL/Q=
+github.com/openshift/library-go v0.0.0-20201012194941-89c1c3827d6f/go.mod h1:NI6xOQGuTnLXeHW8Z2glKSFhF7X+YxlAlqlBMaK0zEM=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/migration_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/migration_controller.go
@@ -246,6 +246,9 @@ func (c *migrationController) migrateKeysIfNeededAndRevisionStable(syncContext f
 			}
 
 			changed, err := setResourceMigrated(gr, s)
+			if err != nil {
+				return err
+			}
 			if !changed {
 				return nil
 			}

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/admissions.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/admissions.go
@@ -1,0 +1,77 @@
+package resourceapply
+
+import (
+	"context"
+
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	admissionclientv1 "k8s.io/client-go/kubernetes/typed/admissionregistration/v1"
+	"k8s.io/klog/v2"
+
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
+)
+
+// ApplyValidatingWebhookConfiguration merges objectmeta, update webhooks.
+func ApplyValidatingWebhookConfiguration(client admissionclientv1.ValidatingWebhookConfigurationsGetter, recorder events.Recorder, required *admissionv1.ValidatingWebhookConfiguration) (*admissionv1.ValidatingWebhookConfiguration, bool, error) {
+	existing, err := client.ValidatingWebhookConfigurations().Get(context.TODO(), required.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		actual, err := client.ValidatingWebhookConfigurations().
+			Create(context.TODO(), required, metav1.CreateOptions{})
+		reportCreateEvent(recorder, required, err)
+		return actual, true, err
+	}
+	if err != nil {
+		return nil, false, err
+	}
+
+	modified := resourcemerge.BoolPtr(false)
+	existingCopy := existing.DeepCopy()
+
+	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
+	contentSame := equality.Semantic.DeepEqual(existingCopy.Webhooks, required.Webhooks)
+	if contentSame && !*modified {
+		return existingCopy, false, nil
+	}
+
+	if klog.V(4).Enabled() {
+		klog.Infof("ValidatingWebhookConfiguration %q changes: %v", required.Name, JSONPatchNoError(existing, required))
+	}
+
+	actual, err := client.ValidatingWebhookConfigurations().Update(context.TODO(), required, metav1.UpdateOptions{})
+	reportUpdateEvent(recorder, required, err)
+	return actual, true, err
+}
+
+// ApplyMutatingWebhookConfiguration merges objectmeta, update webhooks.
+func ApplyMutatingWebhookConfiguration(client admissionclientv1.MutatingWebhookConfigurationsGetter, recorder events.Recorder, required *admissionv1.MutatingWebhookConfiguration) (*admissionv1.MutatingWebhookConfiguration, bool, error) {
+	existing, err := client.MutatingWebhookConfigurations().Get(context.TODO(), required.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		actual, err := client.MutatingWebhookConfigurations().
+			Create(context.TODO(), required, metav1.CreateOptions{})
+		reportCreateEvent(recorder, required, err)
+		return actual, true, err
+	}
+	if err != nil {
+		return nil, false, err
+	}
+
+	modified := resourcemerge.BoolPtr(false)
+	existingCopy := existing.DeepCopy()
+
+	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
+	contentSame := equality.Semantic.DeepEqual(existingCopy.Webhooks, required.Webhooks)
+	if contentSame && !*modified {
+		return existingCopy, false, nil
+	}
+
+	if klog.V(4).Enabled() {
+		klog.Infof("ValidatingWebhookConfiguration %q changes: %v", required.Name, JSONPatchNoError(existing, required))
+	}
+
+	actual, err := client.MutatingWebhookConfigurations().Update(context.TODO(), required, metav1.UpdateOptions{})
+	reportUpdateEvent(recorder, required, err)
+	return actual, true, err
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/generic.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/generic.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/openshift/api"
 	"github.com/openshift/library-go/pkg/operator/events"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -165,6 +166,16 @@ func ApplyDirectly(clients *ClientHolder, recorder events.Recorder, manifests As
 				result.Error = fmt.Errorf("missing kubeClient")
 			}
 			result.Result, result.Changed, result.Error = ApplyCSIDriver(clients.kubeClient.StorageV1(), recorder, t)
+		case *admissionv1.ValidatingWebhookConfiguration:
+			if clients.kubeClient == nil {
+				result.Error = fmt.Errorf("missing kubeClient")
+			}
+			result.Result, result.Changed, result.Error = ApplyValidatingWebhookConfiguration(clients.kubeClient.AdmissionregistrationV1(), recorder, t)
+		case *admissionv1.MutatingWebhookConfiguration:
+			if clients.kubeClient == nil {
+				result.Error = fmt.Errorf("missing kubeClient")
+			}
+			result.Result, result.Changed, result.Error = ApplyMutatingWebhookConfiguration(clients.kubeClient.AdmissionregistrationV1(), recorder, t)
 		default:
 			result.Error = fmt.Errorf("unhandled type %T", requiredObj)
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -214,7 +214,7 @@ github.com/openshift/client-go/operator/listers/operator/v1alpha1
 github.com/openshift/client-go/operatorcontrolplane/clientset/versioned
 github.com/openshift/client-go/operatorcontrolplane/clientset/versioned/scheme
 github.com/openshift/client-go/operatorcontrolplane/clientset/versioned/typed/operatorcontrolplane/v1alpha1
-# github.com/openshift/library-go v0.0.0-20200930152912-7219e4f70a45
+# github.com/openshift/library-go v0.0.0-20201012194941-89c1c3827d6f
 github.com/openshift/library-go/pkg/apps/deployment
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/config/client


### PR DESCRIPTION
Pickup https://github.com/openshift/library-go/pull/918.
Works with https://github.com/openshift/cluster-kube-apiserver-operator/pull/978.

