### PR TITLE
connectivitycheckcontroller: disable by default

### DIFF
--- a/pkg/operator/connectivitycheckcontroller/connectivity_check_controller.go
+++ b/pkg/operator/connectivitycheckcontroller/connectivity_check_controller.go
@@ -59,7 +59,7 @@ func NewOpenshiftAPIServerConnectivityCheckController(
 				configInformers.Config().V1().Infrastructures().Informer(),
 			},
 			recorder,
-			true,
+			false,
 		),
 	}
 	generator := &connectivityCheckTemplateProvider{

--- a/test/e2e/connectivity_check_test.go
+++ b/test/e2e/connectivity_check_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestConnectivityChecksCreated(t *testing.T) {
+	t.Skip("Connectivity Checks disabled.")
 	kubeConfig, err := test.NewClientConfigForTest()
 	require.NoError(t, err)
 	operatorControlPlaneClient, err := operatorcontrolplaneclient.NewForConfig(kubeConfig)


### PR DESCRIPTION
Turning off again as it is preventing 4.6.0 -> 4.7 from completing successfully.