### PR TITLE
enable etcd latency metric

### DIFF
--- a/manifests/0000_90_openshift-apiserver-operator_04_servicemonitor-apiserver.yaml
+++ b/manifests/0000_90_openshift-apiserver-operator_04_servicemonitor-apiserver.yaml
@@ -46,7 +46,7 @@ spec:
     interval: 30s
     metricRelabelings:
     - action: drop
-      regex: etcd_(debugging|disk|request|server).*
+      regex: etcd_(debugging|disk|server).*
       sourceLabels:
       - __name__
     - action: drop


### PR DESCRIPTION
openshift-apiserver has a histogram `etcd_request_duration_seconds` that measures latency between the kube-apiserver and etcd instance. This metrics is currently dropped by cluster-prometheus. Enable this metrics in OpenShift so we have visibility into etcd latency.

We ensured that this does not enable other unwanted metrcis
> count by(__name__) ({__name__=~"etcd_request.+"})

etcd_request_duration_seconds_bucket
etcd_request_duration_seconds_count
etcd_request_duration_seconds_sum

Related PR: https://github.com/openshift/cluster-kube-apiserver-operator/pull/897