### PR TITLE
Use more restrictive defaultMode for secret mounts

### DIFF
--- a/bindata/v3.11.0/openshift-apiserver/deploy.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/deploy.yaml
@@ -154,6 +154,7 @@ spec:
       - name: etcd-client
         secret:
           secretName: etcd-client
+          defaultMode: 0600
       - name: etcd-serving-ca
         configMap:
           name: etcd-serving-ca
@@ -164,6 +165,7 @@ spec:
       - name: serving-cert
         secret:
           secretName: serving-cert
+          defaultMode: 0600
       - name: trusted-ca-bundle
         configMap:
           name: trusted-ca-bundle
@@ -175,6 +177,7 @@ spec:
         secret:
           secretName: encryption-config-${REVISION}
           optional: true
+          defaultMode: 0600
       - hostPath:
           path: /var/log/openshift-apiserver
         name: audit-dir

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -305,6 +305,7 @@ spec:
       - name: etcd-client
         secret:
           secretName: etcd-client
+          defaultMode: 0600
       - name: etcd-serving-ca
         configMap:
           name: etcd-serving-ca
@@ -315,6 +316,7 @@ spec:
       - name: serving-cert
         secret:
           secretName: serving-cert
+          defaultMode: 0600
       - name: trusted-ca-bundle
         configMap:
           name: trusted-ca-bundle
@@ -326,6 +328,7 @@ spec:
         secret:
           secretName: encryption-config-${REVISION}
           optional: true
+          defaultMode: 0600
       - hostPath:
           path: /var/log/openshift-apiserver
         name: audit-dir


### PR DESCRIPTION
This uses a more restrictive file mode for the mounted secrets for the
openshift-apiserver container. By the default, the resulting mode of the
files will be 0644, which is not ideal. So let's use 0600 which ensures
that the files are only accessible by root.