### PR TITLE
Bug 1905298: openshift-apiserver initContainer fix-audit-permissions is not requesting required resources: cpu, memory 

### DIFF
--- a/bindata/v3.11.0/openshift-apiserver/deploy.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/deploy.yaml
@@ -49,6 +49,10 @@ spec:
           command: ['sh', '-c', 'chmod 0700 /var/log/openshift-apiserver && touch /var/log/openshift-apiserver/audit.log && chmod 0600 /var/log/openshift-apiserver/*']
           securityContext:
             privileged: true
+          resources:
+            requests:
+              cpu: 15m
+              memory: 50Mi
           volumeMounts:
             - mountPath: /var/log/openshift-apiserver
               name: audit-dir

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -200,6 +200,10 @@ spec:
           command: ['sh', '-c', 'chmod 0700 /var/log/openshift-apiserver && touch /var/log/openshift-apiserver/audit.log && chmod 0600 /var/log/openshift-apiserver/*']
           securityContext:
             privileged: true
+          resources:
+            requests:
+              cpu: 15m
+              memory: 50Mi
           volumeMounts:
             - mountPath: /var/log/openshift-apiserver
               name: audit-dir


### PR DESCRIPTION
Control plane containers should have requests set for cpu and memory.