### PR TITLE
Bug 1934400: deployment: specifically allow privilege escalation

### DIFF
--- a/bindata/v3.11.0/openshift-apiserver/deploy.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/deploy.yaml
@@ -49,6 +49,7 @@ spec:
           command: ['sh', '-c', 'chmod 0700 /var/log/openshift-apiserver && touch /var/log/openshift-apiserver/audit.log && chmod 0600 /var/log/openshift-apiserver/*']
           securityContext:
             privileged: true
+            allowPrivilegeEscalation: true
           resources:
             requests:
               cpu: 15m
@@ -76,6 +77,7 @@ spec:
         # we need to set this to privileged to be able to write audit to /var/log/openshift-apiserver
         securityContext:
           privileged: true
+          allowPrivilegeEscalation: true
         ports:
         - containerPort: 8443
         volumeMounts:

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -200,6 +200,7 @@ spec:
           command: ['sh', '-c', 'chmod 0700 /var/log/openshift-apiserver && touch /var/log/openshift-apiserver/audit.log && chmod 0600 /var/log/openshift-apiserver/*']
           securityContext:
             privileged: true
+            allowPrivilegeEscalation: true
           resources:
             requests:
               cpu: 15m
@@ -227,6 +228,7 @@ spec:
         # we need to set this to privileged to be able to write audit to /var/log/openshift-apiserver
         securityContext:
           privileged: true
+          allowPrivilegeEscalation: true
         ports:
         - containerPort: 8443
         volumeMounts:


### PR DESCRIPTION
An SCC that allows privileged containers but defaults allowing
privilege escalation in containers might nuke the apiservers on restart.

---
Apparently IBM started distributing such an SCC with priority:1 in their Cloud Paks multi-cluster-management offerings. Such an SCC is very likely to break any container that sets privileged: true but does not set allowPrivilegeEscalation: true (as one would expect that to be implied by the system).

/assign @sttts 