### PR TITLE
expose pod information to oas container via env variables

### DIFF
--- a/bindata/v3.11.0/openshift-apiserver/deploy.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/deploy.yaml
@@ -73,6 +73,15 @@ spec:
           requests:
             memory: 200Mi
             cpu: 100m
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         # we need to set this to privileged to be able to write audit to /var/log/openshift-apiserver
         securityContext:
           privileged: true

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -224,6 +224,15 @@ spec:
           requests:
             memory: 200Mi
             cpu: 100m
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         # we need to set this to privileged to be able to write audit to /var/log/openshift-apiserver
         securityContext:
           privileged: true


### PR DESCRIPTION
the pod name and the namespace are used by the termination code to properly record events.

before the change the termination events were recorded to the default namespace and weren't associated with any pod.
after the change, the termination evens are recorded in the openshift-apiserver namespace and are bound to oas pods.