### PR TITLE
extends shutdown delay duration to 10 seconds

### DIFF
--- a/bindata/v3.11.0/config/defaultconfig.yaml
+++ b/bindata/v3.11.0/config/defaultconfig.yaml
@@ -15,6 +15,6 @@ apiServerArguments:
   audit-policy-file:
   - /var/run/configmaps/audit/default.yaml
   shutdown-delay-duration:
-  - 3s # give SDN some time to converge
+  - 10s # give SDN some time to converge
 servingInfo:
   bindNetwork: "tcp"

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -78,7 +78,7 @@ apiServerArguments:
   audit-policy-file:
   - /var/run/configmaps/audit/default.yaml
   shutdown-delay-duration:
-  - 3s # give SDN some time to converge
+  - 10s # give SDN some time to converge
 servingInfo:
   bindNetwork: "tcp"
 `)


### PR DESCRIPTION
The general rule of thumb is to wait ~5s-10s for any service behind the service network.
During that time the controllers should remove the endpoint from the pool and the application won't receive any new connections.


xref: https://github.com/openshift/openshift-apiserver/pull/198