### PR TITLE
Add management workload annotations

### DIFF
--- a/bindata/v3.11.0/openshift-apiserver/deploy.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/deploy.yaml
@@ -38,6 +38,8 @@ spec:
       labels:
         app: openshift-apiserver-a
         apiserver: "true"
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       serviceAccountName: openshift-apiserver-sa
       priorityClassName: system-node-critical

--- a/bindata/v3.11.0/openshift-apiserver/ns.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/ns.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   annotations:
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   name: openshift-apiserver
   labels:
     openshift.io/run-level-: "" # remove the label if previously set

--- a/manifests/0000_30_openshift-apiserver-operator_00_namespace.yaml
+++ b/manifests/0000_30_openshift-apiserver-operator_00_namespace.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   labels:
     openshift.io/cluster-monitoring: "true"
   name: openshift-apiserver-operator

--- a/manifests/0000_30_openshift-apiserver-operator_07_deployment.yaml
+++ b/manifests/0000_30_openshift-apiserver-operator_07_deployment.yaml
@@ -21,6 +21,8 @@ spec:
       name: openshift-apiserver-operator
       labels:
         app: openshift-apiserver-operator
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       serviceAccountName: openshift-apiserver-operator
       containers:

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -189,6 +189,8 @@ spec:
       labels:
         app: openshift-apiserver-a
         apiserver: "true"
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       serviceAccountName: openshift-apiserver-sa
       priorityClassName: system-node-critical
@@ -394,6 +396,7 @@ kind: Namespace
 metadata:
   annotations:
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   name: openshift-apiserver
   labels:
     openshift.io/run-level-: "" # remove the label if previously set


### PR DESCRIPTION
In support of the workload partitioning feature
(https://github.com/openshift/enhancements/pull/703), we need to add
annotations to all management pods and namespaces so they can be
properly identified and assigned to segregated management cores on
clusters configured to do so.