### PR TITLE
Rename workload annotations

### DIFF
--- a/bindata/v3.11.0/openshift-apiserver/deploy.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/deploy.yaml
@@ -39,7 +39,7 @@ spec:
         app: openshift-apiserver-a
         apiserver: "true"
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       serviceAccountName: openshift-apiserver-sa
       priorityClassName: system-node-critical

--- a/manifests/0000_30_openshift-apiserver-operator_07_deployment.yaml
+++ b/manifests/0000_30_openshift-apiserver-operator_07_deployment.yaml
@@ -22,7 +22,7 @@ spec:
       labels:
         app: openshift-apiserver-operator
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       serviceAccountName: openshift-apiserver-operator
       containers:

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -190,7 +190,7 @@ spec:
         app: openshift-apiserver-a
         apiserver: "true"
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       serviceAccountName: openshift-apiserver-sa
       priorityClassName: system-node-critical


### PR DESCRIPTION
As per https://github.com/openshift/enhancements/pull/739, the workload
annotations names are changing.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>

/hold
Hold until after https://github.com/openshift/kubernetes/pull/632 is merged please