### PR TITLE
Bug 1943804: stub for splitting encryption tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,14 @@ test-e2e-encryption: GO_TEST_FLAGS += -parallel 1
 test-e2e-encryption: test-unit
 .PHONY: test-e2e-encryption
 
+# these are extremely slow serial e2e encryption rotation tests that modify the cluster's global state
+test-e2e-encryption-rotation: GO_TEST_PACKAGES :=./test/e2e-encryption-rotation/...
+test-e2e-encryption-rotation: GO_TEST_FLAGS += -v
+test-e2e-encryption-rotation: GO_TEST_FLAGS += -timeout 4h
+test-e2e-encryption-rotation: GO_TEST_FLAGS += -p 1
+test-e2e-encryption-rotation: test-unit
+.PHONY: test-e2e-encryption-rotation
+
 .PHONY: test-e2e
 test-e2e: GO_TEST_PACKAGES :=./test/e2e/...
 test-e2e: GO_TEST_FLAGS += -timeout 1h

--- a/test/e2e-encryption-rotation/e2e-encryption-rotation_test.go
+++ b/test/e2e-encryption-rotation/e2e-encryption-rotation_test.go
@@ -1,0 +1,9 @@
+package e2e_encryption_rotation
+
+import "testing"
+
+// TestEncryptionRotation first encrypts data with aescbc key
+// then it forces a key rotation by setting the "encyrption.Reason" in the operator's configuration file
+func TestEncryptionRotation(t *testing.T) {
+	t.Log("implement me")
+}


### PR DESCRIPTION
We are going to move the rotation tests to a separate CI job. It will shorten the overall time needed to test encryption but also increase the pass rate of the tests as we have seen them frequently failing due to a timeout.

This PR adds only a stub so that the new CI job can be configured.

We have already split the tests for kas-o in https://github.com/openshift/cluster-kube-apiserver-operator/pull/1131