### PR TITLE
Bug 1986829: metrics: use client cert auth for metrics scraping

### DIFF
--- a/manifests/0000_90_openshift-apiserver-operator_03_servicemonitor.yaml
+++ b/manifests/0000_90_openshift-apiserver-operator_03_servicemonitor.yaml
@@ -21,6 +21,8 @@ spec:
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
       serverName: metrics.openshift-apiserver-operator.svc
+      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
   jobLabel: component
   namespaceSelector:
     matchNames:

--- a/manifests/0000_90_openshift-apiserver-operator_04_servicemonitor-apiserver.yaml
+++ b/manifests/0000_90_openshift-apiserver-operator_04_servicemonitor-apiserver.yaml
@@ -77,6 +77,8 @@ spec:
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
       serverName: api.openshift-apiserver.svc
+      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
   namespaceSelector:
     matchNames:
     - openshift-apiserver

--- a/manifests/0000_90_openshift-apiserver-operator_05_check-endpoints_servicemonitor.yaml
+++ b/manifests/0000_90_openshift-apiserver-operator_05_check-endpoints_servicemonitor.yaml
@@ -15,6 +15,8 @@ spec:
     scheme: https
     tlsConfig:
       insecureSkipVerify: true
+      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
   jobLabel: component
   namespaceSelector:
     matchNames:


### PR DESCRIPTION
The CMO is now capable of using client cert auth to scrape the metrics endpoints. Use that in our components to reduce API load and allow metrics collection when the API is down - given further authz conditions are met.