### PR TITLE
Bug 1960680: bindata: run openshift-apiserver as root explicitly.

### DIFF
--- a/bindata/v3.11.0/openshift-apiserver/deploy.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/deploy.yaml
@@ -51,6 +51,7 @@ spec:
           command: ['sh', '-c', 'chmod 0700 /var/log/openshift-apiserver && touch /var/log/openshift-apiserver/audit.log && chmod 0600 /var/log/openshift-apiserver/*']
           securityContext:
             privileged: true
+            runAsUser: 0
           resources:
             requests:
               cpu: 15m
@@ -88,6 +89,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: false
+          runAsUser: 0
         ports:
         - containerPort: 8443
         volumeMounts:

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -202,6 +202,7 @@ spec:
           command: ['sh', '-c', 'chmod 0700 /var/log/openshift-apiserver && touch /var/log/openshift-apiserver/audit.log && chmod 0600 /var/log/openshift-apiserver/*']
           securityContext:
             privileged: true
+            runAsUser: 0
           resources:
             requests:
               cpu: 15m
@@ -239,6 +240,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: false
+          runAsUser: 0
         ports:
         - containerPort: 8443
         volumeMounts:


### PR DESCRIPTION
openshift-apiserver needs to run as root in order to be able to write audit to /var/log/openshift-apiserver.
Currently only "priviledged: true" is specified which can lead to picking SCCs that do not have the RunAsAny policy.

This fixes it by specifying runAsUser: 0 explicitly.

/cc @stlaz @sttts 