### PR TITLE
[release-4.6] Bug 1996051: bindata: run openshift-apiserver as root explicitly.

### DIFF
--- a/bindata/v3.11.0/openshift-apiserver/deploy.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/deploy.yaml
@@ -49,6 +49,7 @@ spec:
           command: ['sh', '-c', 'chmod 0700 /var/log/openshift-apiserver']
           securityContext:
             privileged: true
+            runAsUser: 0
           volumeMounts:
             - mountPath: /var/log/openshift-apiserver
               name: audit-dir
@@ -72,6 +73,7 @@ spec:
         # we need to set this to privileged to be able to write audit to /var/log/openshift-apiserver
         securityContext:
           privileged: true
+          runAsUser: 0
           readOnlyRootFilesystem: false
         ports:
         - containerPort: 8443

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -200,6 +200,7 @@ spec:
           command: ['sh', '-c', 'chmod 0700 /var/log/openshift-apiserver']
           securityContext:
             privileged: true
+            runAsUser: 0
           volumeMounts:
             - mountPath: /var/log/openshift-apiserver
               name: audit-dir
@@ -223,6 +224,7 @@ spec:
         # we need to set this to privileged to be able to write audit to /var/log/openshift-apiserver
         securityContext:
           privileged: true
+          runAsUser: 0
           readOnlyRootFilesystem: false
         ports:
         - containerPort: 8443


### PR DESCRIPTION
This is a manual cherry-pick of #465