### PR TITLE
[release-4.6] Bug 1955506: explicitly allow apiserver pods to write to their root FS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ test-e2e-encryption-perf: test-unit
 
 .PHONY: test-e2e
 test-e2e: GO_TEST_PACKAGES :=./test/e2e/...
+test-e2e: GO_TEST_FLAGS += -timeout 1h
 test-e2e: test-unit
 
 # Configure the 'telepresence' target

--- a/bindata/v3.11.0/openshift-apiserver/deploy.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/deploy.yaml
@@ -72,6 +72,7 @@ spec:
         # we need to set this to privileged to be able to write audit to /var/log/openshift-apiserver
         securityContext:
           privileged: true
+          readOnlyRootFilesystem: false
         ports:
         - containerPort: 8443
         volumeMounts:

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -223,6 +223,7 @@ spec:
         # we need to set this to privileged to be able to write audit to /var/log/openshift-apiserver
         securityContext:
           privileged: true
+          readOnlyRootFilesystem: false
         ports:
         - containerPort: 8443
         volumeMounts:


### PR DESCRIPTION
This is a manual cherry-pick of #437 adding Makefile config in order to make the tests pass

/assign stlaz