### PR TITLE
podsecurity: enforce privileged for openshift-apiserver namespace

### DIFF
--- a/bindata/v3.11.0/openshift-apiserver/ns.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/ns.yaml
@@ -8,3 +8,9 @@ metadata:
   labels:
     openshift.io/run-level-: "" # remove the label if previously set
     openshift.io/cluster-monitoring: "true"
+    # needs to be privileged because of:
+    # - hostPath volumes (volumes \"node-pullsecrets\", \"audit-dir\")
+    # - privileged (containers \"fix-audit-permissions\", \"openshift-apiserver\"
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -405,6 +405,12 @@ metadata:
   labels:
     openshift.io/run-level-: "" # remove the label if previously set
     openshift.io/cluster-monitoring: "true"
+    # needs to be privileged because of:
+    # - hostPath volumes (volumes \"node-pullsecrets\", \"audit-dir\")
+    # - privileged (containers \"fix-audit-permissions\", \"openshift-apiserver\"
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
 `)
 
 func v3110OpenshiftApiserverNsYamlBytes() ([]byte, error) {


### PR DESCRIPTION
Starting with OpenShift 4.10 we are introducing PodSecurity admission (https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/2579-psp-replacement).

Currently, all pods are marked as privileged, however, over time we want to enforce at least baseline, admirably restricted as default. In order not to break control plane workloads this allows workloads in `openshift-apiserver` namespace to run privileged pods.

See https://github.com/openshift/enhancements/pull/899 for more details (and excuse the eventual consistency of updates).

/cc @stlaz 