### PR TITLE
Bug 1994655: apiservice-controller: don't update the failing condition when an operator has been requested to shutdown

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/openshift/api v0.0.0-20210521075222-e273a339932a
 	github.com/openshift/build-machinery-go v0.0.0-20210423112049-9415d7ebd33e
 	github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142
-	github.com/openshift/library-go v0.0.0-20210727084322-8a96c0a97c06
+	github.com/openshift/library-go v0.0.0-20210914072922-d61f9f640f19
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -408,8 +408,8 @@ github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142 h1:ZHRIMCFIJN1
 github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142/go.mod h1:fjS8r9mqDVsPb5td3NehsNOAWa4uiFkYEfVZioQ2gH0=
 github.com/openshift/kubernetes-apiserver v0.0.0-20210419140141-620426e63a99 h1:KrCYRAJcgZYzMCB1PjJHJMYPu/d+dEkelq5eYyi0fDw=
 github.com/openshift/kubernetes-apiserver v0.0.0-20210419140141-620426e63a99/go.mod h1:w2YSn4/WIwYuxG5zJmcqtRdtqgW/J2JRgFAqps3bBpg=
-github.com/openshift/library-go v0.0.0-20210727084322-8a96c0a97c06 h1:WWpq96l210DQR5XiTNwwEf4wFZUqJIKnAcLt+bLthrI=
-github.com/openshift/library-go v0.0.0-20210727084322-8a96c0a97c06/go.mod h1:C5DDOSPucn3EVA0T05fODKtAweTObMBrTYm/G3uUBI8=
+github.com/openshift/library-go v0.0.0-20210914072922-d61f9f640f19 h1:R861M3Kn70dAU7Cg0nxHgFl+gOqAN1x76I+nkb/LmM8=
+github.com/openshift/library-go v0.0.0-20210914072922-d61f9f640f19/go.mod h1:C5DDOSPucn3EVA0T05fODKtAweTObMBrTYm/G3uUBI8=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/vendor/github.com/openshift/library-go/pkg/operator/apiserver/controller/apiservice/apiservice_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/apiserver/controller/apiservice/apiservice_controller.go
@@ -120,6 +120,19 @@ func (c *APIServiceController) sync(ctx context.Context, syncCtx factory.SyncCon
 
 	err = c.syncAPIServices(apiServices, syncCtx.Recorder())
 
+	if err != nil {
+		// a closed context indicates that the process has been requested to shutdown
+		// in that case we might have failed to check availability of the downstream servers due to the context being closed
+		// in that case don't report the failure to avoid false positives and changing the condition of the operator
+		// the next process will perform the checks immediately after the startup
+		select {
+		case <-ctx.Done():
+			nerr := fmt.Errorf("the operator is shutting down, skipping updating availability of the aggreaged APIs, err = %v", err)
+			return nerr
+		default:
+		}
+	}
+
 	// update failing condition
 	cond := operatorv1.OperatorCondition{
 		Type:   "APIServicesAvailable",

--- a/vendor/github.com/openshift/library-go/pkg/operator/revisioncontroller/revision_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/revisioncontroller/revision_controller.go
@@ -234,7 +234,6 @@ func (c RevisionController) createNewRevision(recorder events.Recorder, revision
 		Name:       statusConfigMap.Name,
 		UID:        statusConfigMap.UID,
 	}}
-
 	for _, cm := range c.configMaps {
 		obj, _, err := resourceapply.SyncConfigMap(c.configMapGetter, recorder, c.targetNamespace, cm.Name, c.targetNamespace, nameFor(cm.Name, revision), ownerRefs)
 		if err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -222,7 +222,7 @@ github.com/openshift/client-go/operatorcontrolplane/clientset/versioned/scheme
 github.com/openshift/client-go/operatorcontrolplane/clientset/versioned/typed/operatorcontrolplane/v1alpha1
 github.com/openshift/client-go/route/clientset/versioned/scheme
 github.com/openshift/client-go/route/clientset/versioned/typed/route/v1
-# github.com/openshift/library-go v0.0.0-20210727084322-8a96c0a97c06
+# github.com/openshift/library-go v0.0.0-20210914072922-d61f9f640f19
 ## explicit
 github.com/openshift/library-go/pkg/apps/deployment
 github.com/openshift/library-go/pkg/assets


### PR DESCRIPTION
clean pick of https://github.com/openshift/library-go/pull/1210

Fixes the following issue:
When an operator is shutting down the `apiservice-controller` might fail on checking the availability of the downstream servers due to the context being closed. The condition (Available) will manifest in the operator's status. This PR simply avoids updating the condition when the process is shutting down.


1.  If the Bugzilla associated with the PR has the "FastFix" keyword, the subjective assessment on the issue has already been done and a customer is impacted. These PRs should be prioritized for merge.
    - [ ] verified
    - [x] does not apply
2. The bug has significant impact either through severity, reduction in supportability, or number of users affected.
    - [x] verified
    - [ ] does not apply
3. For branches that are in the Maintenance lifecycle phase:
    - [ ] The bug is a critical fix, no reasonable workaround exists, and a recommendation for upgrade has been ruled out, or 
    - [ ] The bug is a security related bug
    - [x] Branch not in maintenance mode yet (current release + previous release for 90 days after current GA; everything older is in maintenance)
4. The severity field of the bug must be set to accurately reflect criticality.
    - [x] verified
5. The PR was created with the cherry-pick bot OR the PR’s description is well formed with user-focused release notes that state the bug number, impact, cause, and resolution. Where appropriate, it should also contain information about how a user can identify whether a particular cluster is affected.
    - [x] verified