### PR TITLE
Bug 1984592: global pull secret not working in OCP4.7.4+ for additio…

### DIFF
--- a/bindata/v3.11.0/openshift-apiserver/deploy.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/deploy.yaml
@@ -93,7 +93,7 @@ spec:
         ports:
         - containerPort: 8443
         volumeMounts:
-        - mountPath: /var/lib/kubelet/config.json
+        - mountPath: /var/lib/kubelet/
           name: node-pullsecrets
           readOnly: true
         - mountPath: /var/run/configmaps/config
@@ -161,8 +161,8 @@ spec:
       volumes:
       - name: node-pullsecrets
         hostPath:
-          path: /var/lib/kubelet/config.json
-          type: File
+          path: /var/lib/kubelet/
+          type: Directory
       - name: config
         configMap:
           name: config

--- a/pkg/dependencymagnet/doc.go
+++ b/pkg/dependencymagnet/doc.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 // go mod won't pull in code that isn't depended upon, but we have some code we don't depend on from code that must be included

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -245,7 +245,7 @@ spec:
         ports:
         - containerPort: 8443
         volumeMounts:
-        - mountPath: /var/lib/kubelet/config.json
+        - mountPath: /var/lib/kubelet/
           name: node-pullsecrets
           readOnly: true
         - mountPath: /var/run/configmaps/config
@@ -313,8 +313,8 @@ spec:
       volumes:
       - name: node-pullsecrets
         hostPath:
-          path: /var/lib/kubelet/config.json
-          type: File
+          path: /var/lib/kubelet/
+          type: Directory
       - name: config
         configMap:
           name: config


### PR DESCRIPTION
…nal private registries.

This change is needed because otherwise updated pull secret is not reflected in existing openshift-apiserver pods which results in access restriction.