### PR TITLE
[4.11] Bug 2102633: operator NS manifest: Set empty openshift.io/run-level

### DIFF
--- a/manifests/00_namespace.yaml
+++ b/manifests/00_namespace.yaml
@@ -8,5 +8,6 @@ metadata:
     openshift.io/node-selector: ""
     workload.openshift.io/allowed: "management"
   labels:
+    openshift.io/run-level: "" # specify no run-level turns it off on install and upgrades
     openshift.io/cluster-monitoring: "true"
   name: openshift-apiserver-operator


### PR DESCRIPTION
We dropped the run-level label from this namespace back in 4.5
but because of how the cluster-version operator reconciles manifest
labels, dropping a label from the manifest does not remove it from the
in-cluster resource when old clusters are updated into the new
manifest.  This commit uses the approach the cluster-version
operator used to drop its run-level, by setting the value to an
empty string, which the run-level-consuming code treats identically to
an unset label.

This avoids errors about:

  ...container has runAsNonRoot and image will run as root...

when updating to 4.11 in case the operator deployment  manifest specifically
requests runAsNonRoot: true.