### PR TITLE
OCPBUGS-5345: routes/status resources can leak sensitive data, exclude it from audit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/openshift/api v0.0.0-20211209135129-c58d9f695577
 	github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3
 	github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3
-	github.com/openshift/library-go v0.0.0-20220119122101-7e1811fdb665
+	github.com/openshift/library-go v0.0.0-20230104143934-2a49f946ce7a
 	github.com/spf13/cobra v1.2.1
 	github.com/stretchr/testify v1.7.0
 	go.etcd.io/etcd/client/v3 v3.5.0

--- a/go.sum
+++ b/go.sum
@@ -518,8 +518,8 @@ github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3 h1:65
 github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3 h1:SG1aqwleU6bGD0X4mhkTNupjVnByMYYuW4XbnCPavQU=
 github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3/go.mod h1:cwhyki5lqBmrT0m8Im+9I7PGFaraOzcYPtEz93RcsGY=
-github.com/openshift/library-go v0.0.0-20220119122101-7e1811fdb665 h1:pzSrFYDV8k/41VreHttHb/OewcMNwk5pNKlmCxDD0bI=
-github.com/openshift/library-go v0.0.0-20220119122101-7e1811fdb665/go.mod h1:4UQ9snU1vg53fyTpHQw3vLPiAxI8ub5xrc+y8KPQQFs=
+github.com/openshift/library-go v0.0.0-20230104143934-2a49f946ce7a h1:EBz71dxux8ZYLdXb/Ftff4XsoOFuwIHPsg/HR0SmikU=
+github.com/openshift/library-go v0.0.0-20230104143934-2a49f946ce7a/go.mod h1:6AmNM4N4nHftckybV/U7bQW+5AvK5TW81ndSI6KEidw=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=

--- a/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/bindata/bindata.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/bindata/bindata.go
@@ -62,7 +62,7 @@ var _pkgOperatorApiserverAuditManifestsAllrequestbodiesRulesYaml = []byte(`# exc
 - level: Metadata
   resources:
   - group: "route.openshift.io"
-    resources: ["routes"]
+    resources: ["routes", "routes/status"]
   - resources: ["secrets"]
 - level: Metadata
   resources:
@@ -107,6 +107,13 @@ var _pkgOperatorApiserverAuditManifestsBasePolicyYaml = []byte(`    apiVersion: 
       - "/version"
       - "/healthz"
       - "/readyz"
+    # Don't log requests by "system:apiserver" on apirequestcounts
+    - level: None
+      users: ["system:apiserver"]
+      resources:
+        - group: "apiserver.openshift.io"
+          resources: ["apirequestcounts", "apirequestcounts/*"]
+      namespaces: [""]
 `)
 
 func pkgOperatorApiserverAuditManifestsBasePolicyYamlBytes() ([]byte, error) {
@@ -177,7 +184,7 @@ var _pkgOperatorApiserverAuditManifestsWriterequestbodiesRulesYaml = []byte(`# e
 - level: Metadata
   resources:
   - group: "route.openshift.io"
-    resources: ["routes"]
+    resources: ["routes", "routes/status"]
   - resources: ["secrets"]
 - level: Metadata
   resources:

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/generic.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/generic.go
@@ -206,13 +206,13 @@ func ApplyDirectly(ctx context.Context, clients *ClientHolder, recorder events.R
 			if clients.kubeClient == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
 			} else {
-				result.Result, result.Changed, result.Error = ApplyValidatingWebhookConfiguration(ctx, clients.kubeClient.AdmissionregistrationV1(), recorder, t)
+				result.Result, result.Changed, result.Error = ApplyValidatingWebhookConfigurationImproved(ctx, clients.kubeClient.AdmissionregistrationV1(), recorder, t, cache)
 			}
 		case *admissionregistrationv1.MutatingWebhookConfiguration:
 			if clients.kubeClient == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
 			} else {
-				result.Result, result.Changed, result.Error = ApplyMutatingWebhookConfiguration(ctx, clients.kubeClient.AdmissionregistrationV1(), recorder, t)
+				result.Result, result.Changed, result.Error = ApplyMutatingWebhookConfigurationImproved(ctx, clients.kubeClient.AdmissionregistrationV1(), recorder, t, cache)
 			}
 		case *storagev1.CSIDriver:
 			if clients.kubeClient == nil {

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/storage.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/storage.go
@@ -2,6 +2,7 @@ package resourceapply
 
 import (
 	"context"
+	"fmt"
 
 	storagev1 "k8s.io/api/storage/v1"
 	storagev1beta1 "k8s.io/api/storage/v1beta1"
@@ -52,10 +53,57 @@ func ApplyStorageClass(ctx context.Context, client storageclientv1.StorageClasse
 		klog.Infof("StorageClass %q changes: %v", required.Name, JSONPatchNoError(existingCopy, requiredCopy))
 	}
 
-	// TODO if provisioner, parameters, reclaimpolicy, or volumebindingmode are different, update will fail so delete and recreate
+	if storageClassNeedsRecreate(existingCopy, requiredCopy) {
+		requiredCopy.ObjectMeta.ResourceVersion = ""
+		err = client.StorageClasses().Delete(ctx, existingCopy.Name, metav1.DeleteOptions{})
+		reportDeleteEvent(recorder, requiredCopy, err, "Deleting StorageClass to re-create it with updated parameters")
+		if err != nil && !apierrors.IsNotFound(err) {
+			return existing, false, err
+		}
+		actual, err := client.StorageClasses().Create(ctx, requiredCopy, metav1.CreateOptions{})
+		if err != nil && apierrors.IsAlreadyExists(err) {
+			// Delete() few lines above did not really delete the object,
+			// the API server is probably waiting for a finalizer removal or so.
+			// Report an error, but something else than "Already exists", because
+			// that would be very confusing - Apply failed because the object
+			// already exists???
+			err = fmt.Errorf("failed to re-create StorageClass %s, waiting for the original object to be deleted", existingCopy.Name)
+		} else if err != nil {
+			err = fmt.Errorf("failed to re-create StorageClass %s: %s", existingCopy.Name, err)
+		}
+		reportCreateEvent(recorder, actual, err)
+		return actual, true, err
+	}
+
+	// Only mutable fields need a change
 	actual, err := client.StorageClasses().Update(ctx, requiredCopy, metav1.UpdateOptions{})
 	reportUpdateEvent(recorder, required, err)
 	return actual, true, err
+}
+
+func storageClassNeedsRecreate(oldSC, newSC *storagev1.StorageClass) bool {
+	// Based on kubernetes/kubernetes/pkg/apis/storage/validation/validation.go,
+	// these fields are immutable.
+	if !equality.Semantic.DeepEqual(oldSC.Parameters, newSC.Parameters) {
+		return true
+	}
+	if oldSC.Provisioner != newSC.Provisioner {
+		return true
+	}
+
+	// In theory, ReclaimPolicy is always set, just in case:
+	if (oldSC.ReclaimPolicy == nil && newSC.ReclaimPolicy != nil) ||
+		(oldSC.ReclaimPolicy != nil && newSC.ReclaimPolicy == nil) {
+		return true
+	}
+	if oldSC.ReclaimPolicy != nil && newSC.ReclaimPolicy != nil && *oldSC.ReclaimPolicy != *newSC.ReclaimPolicy {
+		return true
+	}
+
+	if !equality.Semantic.DeepEqual(oldSC.VolumeBindingMode, newSC.VolumeBindingMode) {
+		return true
+	}
+	return false
 }
 
 // ApplyCSIDriverV1Beta1 merges objectmeta, does not worry about anything else

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/guard/guard_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/guard/guard_controller.go
@@ -64,7 +64,14 @@ func NewGuardController(
 	pdbGetter policyclientv1.PodDisruptionBudgetsGetter,
 	eventRecorder events.Recorder,
 	createConditionalFunc func() (bool, bool, error),
-) factory.Controller {
+) (factory.Controller, error) {
+	if operandPodLabelSelector == nil {
+		return nil, fmt.Errorf("GuardController: missing required operandPodLabelSelector")
+	}
+	if operandPodLabelSelector.Empty() {
+		return nil, fmt.Errorf("GuardController: operandPodLabelSelector cannot be empty")
+	}
+
 	c := &GuardController{
 		targetNamespace:         targetNamespace,
 		operandPodLabelSelector: operandPodLabelSelector,
@@ -83,7 +90,7 @@ func NewGuardController(
 	return factory.New().WithInformers(
 		kubeInformersForTargetNamespace.Core().V1().Pods().Informer(),
 		kubeInformersClusterScoped.Core().V1().Nodes().Informer(),
-	).WithSync(c.sync).WithSyncDegradedOnError(operatorClient).ToController("GuardController", eventRecorder)
+	).WithSync(c.sync).WithSyncDegradedOnError(operatorClient).ToController("GuardController", eventRecorder), nil
 }
 
 func getInstallerPodImageFromEnv() string {

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticresourcecontroller/static_resource_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticresourcecontroller/static_resource_controller.go
@@ -61,7 +61,7 @@ type StaticResourceController struct {
 	name                   string
 	manifests              []conditionalManifests
 	ignoreNotFoundOnCreate bool
-	preconfitions          []StaticResourcesPreconditionsFuncType
+	preconditions          []StaticResourcesPreconditionsFuncType
 
 	operatorClient v1helpers.OperatorClient
 	clients        *resourceapply.ClientHolder
@@ -106,7 +106,7 @@ func NewStaticResourceController(
 		operatorClient: operatorClient,
 		clients:        clients,
 
-		preconfitions: []StaticResourcesPreconditionsFuncType{defaultStaticResourcesPreconditionsFunc},
+		preconditions: []StaticResourcesPreconditionsFuncType{defaultStaticResourcesPreconditionsFunc},
 
 		eventRecorder: eventRecorder.WithComponentSuffix(strings.ToLower(name)),
 
@@ -136,7 +136,7 @@ func (c *StaticResourceController) WithIgnoreNotFoundOnCreate() *StaticResourceC
 //
 // When the requirement is not met, the controller reports degraded status.
 func (c *StaticResourceController) WithPrecondition(precondition StaticResourcesPreconditionsFuncType) *StaticResourceController {
-	c.preconfitions = append(c.preconfitions, precondition)
+	c.preconditions = append(c.preconditions, precondition)
 	return c
 }
 
@@ -283,7 +283,7 @@ func (c *StaticResourceController) Sync(ctx context.Context, syncContext factory
 		return nil
 	}
 
-	for _, precondition := range c.preconfitions {
+	for _, precondition := range c.preconditions {
 		ready, err := precondition(ctx)
 		// We don't care about the other preconditions, we just stop on the first one.
 		if !ready {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -274,7 +274,7 @@ github.com/openshift/client-go/operatorcontrolplane/clientset/versioned/scheme
 github.com/openshift/client-go/operatorcontrolplane/clientset/versioned/typed/operatorcontrolplane/v1alpha1
 github.com/openshift/client-go/route/clientset/versioned/scheme
 github.com/openshift/client-go/route/clientset/versioned/typed/route/v1
-# github.com/openshift/library-go v0.0.0-20220119122101-7e1811fdb665
+# github.com/openshift/library-go v0.0.0-20230104143934-2a49f946ce7a
 ## explicit; go 1.17
 github.com/openshift/library-go/pkg/apps/deployment
 github.com/openshift/library-go/pkg/assets


### PR DESCRIPTION
re-vendor library-go