### PR TITLE
OCPBUGS-6233: Updating ose-cluster-openshift-apiserver-operator images to be consistent with ART

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.18-openshift-4.11
+  tag: rhel-8-release-golang-1.19-openshift-4.13

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.11 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.13 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-openshift-apiserver-operator
 COPY . .
 RUN GODEBUG=tls13=1 go build ./cmd/cluster-openshift-apiserver-operator
 
-FROM registry.ci.openshift.org/ocp/4.9:base
+FROM registry.ci.openshift.org/ocp/4.13:base
 COPY --from=builder /go/src/github.com/openshift/cluster-openshift-apiserver-operator/cluster-openshift-apiserver-operator /usr/bin/
 COPY manifests /manifests
 COPY vendor/github.com/openshift/api/operator/v1/*_openshift-apiserver-operator_*.crd.yaml manifests/


### PR DESCRIPTION
Copy of https://github.com/openshift/cluster-openshift-apiserver-operator/pull/510 rebased on top of recent changes.

/cc @tkashem 