### PR TITLE
OCPBUGS-8368: manifests: create target namespace earlier

### DIFF
--- a/manifests/0000_10_cluster-openshift-apiserver-operator_00_namespace.yaml
+++ b/manifests/0000_10_cluster-openshift-apiserver-operator_00_namespace.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
+  labels:
+    openshift.io/run-level: "" # specify no run-level turns it off on install and upgrades
+    openshift.io/cluster-monitoring: "true"
+  name: openshift-apiserver


### PR DESCRIPTION
In order to speed up initial install target namespace definition needs to be included in the payload, as these need to have SCCs assigned and its benefitial to do this earlier on startup