### PR TITLE
Add AES-GCM encryption tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
 
 IMAGE_REGISTRY :=registry.svc.ci.openshift.org
 
+ENCRYPTION_PROVIDERS=aescbc aesgcm
+ENCRYPTION_PROVIDER?=aescbc
+
 # This will call a macro called "build-image" which will generate image specific targets based on the parameters:
 # $0 - macro name
 # $1 - target name
@@ -39,22 +42,35 @@ clean:
 
 GO_TEST_PACKAGES :=./pkg/... ./cmd/...
 
+TEST_E2E_ENCRYPTION_TARGETS=$(addprefix test-e2e-encryption-,$(ENCRYPTION_PROVIDERS))
+
 # these are extremely slow serial e2e encryption tests that modify the cluster's global state
 test-e2e-encryption: GO_TEST_PACKAGES :=./test/e2e-encryption/...
 test-e2e-encryption: GO_TEST_FLAGS += -v
 test-e2e-encryption: GO_TEST_FLAGS += -timeout 4h
 test-e2e-encryption: GO_TEST_FLAGS += -p 1
-test-e2e-encryption: GO_TEST_FLAGS += -parallel 1
+test-e2e-encryption: GO_TEST_ARGS += -args -provider=$(ENCRYPTION_PROVIDER)
 test-e2e-encryption: test-unit
 .PHONY: test-e2e-encryption
+
+.PHONY: $(TEST_E2E_ENCRYPTION_TARGETS)
+$(TEST_E2E_ENCRYPTION_TARGETS): test-e2e-encryption-%:
+	ENCRYPTION_PROVIDER=$* $(MAKE) test-e2e-encryption
+
+TEST_E2E_ENCRYPTION_ROTATION_TARGETS=$(addprefix test-e2e-encryption-rotation,$(ENCRYPTION_PROVIDERS))
 
 # these are extremely slow serial e2e encryption rotation tests that modify the cluster's global state
 test-e2e-encryption-rotation: GO_TEST_PACKAGES :=./test/e2e-encryption-rotation/...
 test-e2e-encryption-rotation: GO_TEST_FLAGS += -v
 test-e2e-encryption-rotation: GO_TEST_FLAGS += -timeout 4h
 test-e2e-encryption-rotation: GO_TEST_FLAGS += -p 1
+test-e2e-encryption-rotation: GO_TEST_ARGS += -args -provider=$(ENCRYPTION_PROVIDER)
 test-e2e-encryption-rotation: test-unit
 .PHONY: test-e2e-encryption-rotation
+
+.PHONY: $(TEST_E2E_ENCRYPTION_ROTATION_TARGETS)
+$(TEST_E2E_ENCRYPTION_ROTATION_TARGETS): test-e2e-encryption-rotation%:
+	ENCRYPTION_PROVIDER=$* $(MAKE) test-e2e-encryption-rotation
 
 .PHONY: test-e2e
 test-e2e: GO_TEST_PACKAGES :=./test/e2e/...

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
 	github.com/gonum/graph v0.0.0-20190426092945-678096d81a4b
 	github.com/openshift/api v0.0.0-20230503133300-8bbcb7ca7183
-	github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d
+	github.com/openshift/build-machinery-go v0.0.0-20230228230858-4cd708338479
 	github.com/openshift/client-go v0.0.0-20230503144108-75015d2347cb
 	github.com/openshift/library-go v0.0.0-20230508110756-9b7abe2c9cbf
 	github.com/spf13/cobra v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -485,8 +485,8 @@ github.com/onsi/gomega v1.8.1/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoT
 github.com/onsi/gomega v1.27.4 h1:Z2AnStgsdSayCMDiCU42qIz+HLqEPcgiOCXjAU/w+8E=
 github.com/openshift/api v0.0.0-20230503133300-8bbcb7ca7183 h1:t/CahSnpqY46sQR01SoS+Jt0jtjgmhgE6lFmRnO4q70=
 github.com/openshift/api v0.0.0-20230503133300-8bbcb7ca7183/go.mod h1:4VWG+W22wrB4HfBL88P40DxLEpSOaiBVxUnfalfJo9k=
-github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d h1:RR4ah7FfaPR1WePizm0jlrsbmPu91xQZnAsVVreQV1k=
-github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
+github.com/openshift/build-machinery-go v0.0.0-20230228230858-4cd708338479 h1:IU2KU1kzg7/dfiZO4uPJY1G5Wp1k/IiXfYesc+quwaE=
+github.com/openshift/build-machinery-go v0.0.0-20230228230858-4cd708338479/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20230503144108-75015d2347cb h1:Nij5OnaECrkmcRQMAE9LMbQXPo95aqFnf+12B7SyFVI=
 github.com/openshift/client-go v0.0.0-20230503144108-75015d2347cb/go.mod h1:Rhb3moCqeiTuGHAbXBOlwPubUMlOZEkrEWTRjIF3jzs=
 github.com/openshift/library-go v0.0.0-20230508110756-9b7abe2c9cbf h1:ZpFAN2qprgp7jEhGPrOAwP8mmuYC9BRYzvDefg+k4GM=

--- a/test/e2e-encryption-rotation/e2e-encryption-rotation_test.go
+++ b/test/e2e-encryption-rotation/e2e-encryption-rotation_test.go
@@ -2,21 +2,24 @@ package e2e_encryption_rotation
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
-	configv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/rand"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-openshift-apiserver-operator/pkg/operator/operatorclient"
 	operatorencryption "github.com/openshift/cluster-openshift-apiserver-operator/test/library/encryption"
 	library "github.com/openshift/library-go/test/library/encryption"
 )
+
+var provider = flag.String("provider", "aescbc", "encryption provider used by the tests")
 
 // TestEncryptionRotation first encrypts data with aescbc key
 // then it forces a key rotation by setting the "encyrption.Reason" in the operator's configuration file
@@ -55,6 +58,6 @@ func TestEncryptionRotation(t *testing.T) {
 			_, err = cs.OperatorClient.Update(ctx, apiServerOperator, metav1.UpdateOptions{})
 			return err
 		},
-		EncryptionProvider: configv1.EncryptionType("aescbc"),
+		EncryptionProvider: configv1.EncryptionType(*provider),
 	})
 }

--- a/test/e2e-encryption/encryption_test.go
+++ b/test/e2e-encryption/encryption_test.go
@@ -2,21 +2,24 @@ package e2e_encryption
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
-	configv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/rand"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-openshift-apiserver-operator/pkg/operator/operatorclient"
 	operatorencryption "github.com/openshift/cluster-openshift-apiserver-operator/test/library/encryption"
 	library "github.com/openshift/library-go/test/library/encryption"
 )
+
+var provider = flag.String("provider", "aescbc", "encryption provider used by the tests")
 
 func TestEncryptionTypeIdentity(t *testing.T) {
 	library.TestEncryptionTypeIdentity(t, library.BasicScenario{
@@ -68,6 +71,6 @@ func TestEncryptionTurnOnAndOff(t *testing.T) {
 		AssertResourceNotEncryptedFunc: operatorencryption.AssertRouteOfLifeNotEncrypted,
 		ResourceFunc:                   func(t testing.TB, _ string) runtime.Object { return operatorencryption.RouteOfLife(t, ns) },
 		ResourceName:                   "RouteOfLife",
-		EncryptionProvider:             configv1.EncryptionType("aescbc"),
+		EncryptionProvider:             configv1.EncryptionType(*provider),
 	})
 }

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/golang/test-unit.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/golang/test-unit.mk
@@ -4,11 +4,11 @@ include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
 
 test-unit:
 ifndef JUNITFILE
-	$(GO) test $(GO_MOD_FLAGS) $(GO_TEST_FLAGS) $(GO_TEST_PACKAGES)
+	$(GO) test $(GO_MOD_FLAGS) $(GO_TEST_FLAGS) $(GO_TEST_PACKAGES) $(GO_TEST_ARGS)
 else
 ifeq (, $(shell which gotest2junit 2>/dev/null))
 	$(error gotest2junit not found! Get it by `go get -mod='' -u github.com/openshift/release/tools/gotest2junit`.)
 endif
-	set -o pipefail; $(GO) test $(GO_MOD_FLAGS) $(GO_TEST_FLAGS) -json $(GO_TEST_PACKAGES) | gotest2junit > $(JUNITFILE)
+	set -o pipefail; $(GO) test $(GO_MOD_FLAGS) $(GO_TEST_FLAGS) -json $(GO_TEST_PACKAGES) $(GO_TEST_ARGS) | gotest2junit > $(JUNITFILE)
 endif
 .PHONY: test-unit

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -275,7 +275,7 @@ github.com/openshift/api/template
 github.com/openshift/api/template/v1
 github.com/openshift/api/user
 github.com/openshift/api/user/v1
-# github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d
+# github.com/openshift/build-machinery-go v0.0.0-20230228230858-4cd708338479
 ## explicit; go 1.13
 github.com/openshift/build-machinery-go
 github.com/openshift/build-machinery-go/make


### PR DESCRIPTION
This PR brings the changes from https://github.com/openshift/cluster-kube-apiserver-operator/pull/1449 over to cluster-authentication-operator.

Separately new jobs are being added in https://github.com/openshift/release/pull/40119 in order to run the new AES-GCM encryption tests.