### PR TITLE
AUTH-408: bindata: set required-scc

### DIFF
--- a/bindata/v3.11.0/openshift-apiserver/deploy.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/deploy.yaml
@@ -40,6 +40,7 @@ spec:
         apiserver: "true"
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: 'privileged'
     spec:
       serviceAccountName: openshift-apiserver-sa
       priorityClassName: system-node-critical

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -198,6 +198,7 @@ spec:
         apiserver: "true"
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: 'privileged'
     spec:
       serviceAccountName: openshift-apiserver-sa
       priorityClassName: system-node-critical


### PR DESCRIPTION
This sets the required-scc annotation for openshift-apiserver to `privileged` as openshift-apiserver is a privileged pod.

/cc @deads2k @stlaz 