### PR TITLE
OCPBUGS-18939: manifest: drop slo latency metrics in favor of sli

### DIFF
--- a/manifests/0000_90_openshift-apiserver-operator_04_servicemonitor-apiserver.yaml
+++ b/manifests/0000_90_openshift-apiserver-operator_04_servicemonitor-apiserver.yaml
@@ -68,6 +68,10 @@ spec:
       sourceLabels:
       - __name__
       - le
+    - action: drop
+      regex: apiserver_request_slo_duration_seconds_.*
+      sourceLabels:
+      - __name__
     relabelings:
     - action: replace
       targetLabel: apiserver


### PR DESCRIPTION
The apiserver_request_sli_duration_seconds metric was introduced as a
replacement of apiserver_request_slo_duration_seconds which is
deprecated in Kubernetes 1.27.

To also avoid storing duplicated data in Prometheus, we need to drop
the apiserver_request_slo_duration_seconds at the ServiceMonitor level.