### PR TITLE
OCPBUGS-18115: Remove "include.release.openshift.io/ibm-cloud-managed:" annotation

### DIFF
--- a/manifests/0000_90_openshift-apiserver-operator_04_servicemonitor-apiserver.yaml
+++ b/manifests/0000_90_openshift-apiserver-operator_04_servicemonitor-apiserver.yaml
@@ -46,6 +46,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/manifests/0000_90_openshift-apiserver-operator_04_servicemonitor-apiserver.yaml
+++ b/manifests/0000_90_openshift-apiserver-operator_04_servicemonitor-apiserver.yaml
@@ -43,10 +43,8 @@ metadata:
   name: openshift-apiserver
   namespace: openshift-apiserver
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token


### PR DESCRIPTION
Remove "include.release.openshift.io/ibm-cloud-managed:" annotation annotation to CVO not to deploy the service monitor