### PR TITLE
[release-4.14] OCPBUGS-28247: Remove "include.release.openshift.io/ibm-cloud-managed:" annotation

### DIFF
--- a/manifests/0000_90_openshift-apiserver-operator_04_servicemonitor-apiserver.yaml
+++ b/manifests/0000_90_openshift-apiserver-operator_04_servicemonitor-apiserver.yaml
@@ -43,7 +43,6 @@ metadata:
   name: openshift-apiserver
   namespace: openshift-apiserver
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:

--- a/manifests/0000_90_openshift-apiserver-operator_05_check-endpoints_servicemonitor.yaml
+++ b/manifests/0000_90_openshift-apiserver-operator_05_check-endpoints_servicemonitor.yaml
@@ -4,7 +4,6 @@ metadata:
   name: openshift-apiserver-operator-check-endpoints
   namespace: openshift-apiserver
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:


### PR DESCRIPTION
Cherry-pick of #567 and #551

Supersedes #568 (which lacked the second PR).