### PR TITLE
NO-ISSUE: Makefile: fixes test-e2e-encryption-rotation targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ test-e2e-encryption: test-unit
 $(TEST_E2E_ENCRYPTION_TARGETS): test-e2e-encryption-%:
 	ENCRYPTION_PROVIDER=$* $(MAKE) test-e2e-encryption
 
-TEST_E2E_ENCRYPTION_ROTATION_TARGETS=$(addprefix test-e2e-encryption-rotation,$(ENCRYPTION_PROVIDERS))
+TEST_E2E_ENCRYPTION_ROTATION_TARGETS=$(addprefix test-e2e-encryption-rotation-,$(ENCRYPTION_PROVIDERS))
 
 # these are extremely slow serial e2e encryption rotation tests that modify the cluster's global state
 test-e2e-encryption-rotation: GO_TEST_PACKAGES :=./test/e2e-encryption-rotation/...
@@ -69,7 +69,7 @@ test-e2e-encryption-rotation: test-unit
 .PHONY: test-e2e-encryption-rotation
 
 .PHONY: $(TEST_E2E_ENCRYPTION_ROTATION_TARGETS)
-$(TEST_E2E_ENCRYPTION_ROTATION_TARGETS): test-e2e-encryption-rotation%:
+$(TEST_E2E_ENCRYPTION_ROTATION_TARGETS): test-e2e-encryption-rotation-%:
 	ENCRYPTION_PROVIDER=$* $(MAKE) test-e2e-encryption-rotation
 
 .PHONY: test-e2e


### PR DESCRIPTION
before this change the following targets didn't work:

- make test-e2e-encryption-rotation-aescbc
- make test-e2e-encryption-rotation-aesgcm

as a result corresponding CI jobs failed. For example:
- https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_cluster-openshift-apiserver-operator/575/pull-ci-openshift-cluster-openshift-apiserver-operator-master-e2e-gcp-operator-encryption-rotation-aesgcm/1779820017387311104
- https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_cluster-openshift-apiserver-operator/575/pull-ci-openshift-cluster-openshift-apiserver-operator-master-e2e-gcp-operator-encryption-rotation-aescbc/1779820014874923008

This PR fixes the issue by adding "-" prefix to the targets.