### PR TITLE
[release-4.15] OCPBUGS-36150: Set required-scc for openshift workloads

### DIFF
--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -23,6 +23,7 @@ spec:
         app: openshift-apiserver-operator
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: nonroot-v2
     spec:
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
[OCPBUGS-36150](https://issues.redhat.com/browse/OCPBUGS-36150)

Manual cherry-pick of #573 