### PR TITLE
MULTIARCH-4557: Sync import mode image config status field in the observed config

### DIFF
--- a/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
+++ b/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
@@ -59,6 +59,7 @@ func NewConfigObserver(
 			},
 		},
 		[]factory.Informer{operatorConfigInformers.Operator().V1().OpenShiftAPIServers().Informer()},
+		images.ObserveImagestreamImportMode,
 		images.ObserveInternalRegistryHostname,
 		images.ObserveExternalRegistryHostnames,
 		images.ObserveAllowedRegistriesForImport,


### PR DESCRIPTION
As per https://github.com/openshift/enhancements/pull/1605, there was a
new field introduced in the image config spec and status which reflects
the global value to be set for imagestream import mode which is behind a
featuregate. This PR reads the image config status, checks if the importmode
string is present and syncs that value in the imagepolicyconfig of the
observed config to be used by the apiserver.

API changes: https://github.com/openshift/api/pull/1928
openshift-apiserver changes: https://github.com/openshift/openshift-apiserver/pull/443
image-registry-operator changes: https://github.com/openshift/cluster-image-registry-operator/pull/1090