### PR TITLE
OCPBUGS-48177: Exclude etcd readiness checks from /readyz to ignore temporary etcd hiccups

### DIFF
--- a/bindata/v3.11.0/openshift-apiserver/deploy.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/deploy.yaml
@@ -129,7 +129,7 @@ spec:
           httpGet:
             scheme: HTTPS
             port: 8443
-            path: readyz
+            path: readyz?exclude=etcd&exclude=etcd-readiness
           initialDelaySeconds: 0
           periodSeconds: 5
           timeoutSeconds: 10

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -287,7 +287,7 @@ spec:
           httpGet:
             scheme: HTTPS
             port: 8443
-            path: readyz
+            path: readyz?exclude=etcd&exclude=etcd-readiness
           initialDelaySeconds: 0
           periodSeconds: 5
           timeoutSeconds: 10


### PR DESCRIPTION
Explicitly exclude etcd and etcd-readiness checks (OCPBUGS-48177) and have etcd operator take responsibility for properly reporting etcd readiness. Justification: kube-apiserver instances get removed from a load balancer when etcd starts to report not ready (as will KA's /readyz). Client connections can withstand etcd unreadiness longer than the readiness timeout is. Thus, it is not necessary to drop connections in case etcd resumes its readiness before a client connection times out naturally.

Follow up for https://github.com/openshift/kubernetes/pull/2174