### PR TITLE
Implements rand deprecation by removing seed initializer

### DIFF
--- a/test/e2e-encryption/main_test.go
+++ b/test/e2e-encryption/main_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"reflect"
 	"testing"
-	"time"
 	"unsafe"
 )
 
@@ -24,7 +23,6 @@ func randomizeTestOrder(m *testing.M) {
 
 	tests := *realPtrToTests
 
-	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(tests), func(i, j int) { tests[i], tests[j] = tests[j], tests[i] })
 
 	*realPtrToTests = tests


### PR DESCRIPTION
Go 1.20 automatically seeds the top-level generator and deprecated `rand.Seed`.  Read more [here](https://go.dev/blog/randv2#fix.v1).

Similar to: https://github.com/openshift/cert-manager-operator/pull/243