### PR TITLE
OCPBUGS-56821: Add prometheus alert for image stream import failure

### DIFF
--- a/manifests/0000_90_openshift-apiserver-operator_06_prometheusrule.yaml
+++ b/manifests/0000_90_openshift-apiserver-operator_06_prometheusrule.yaml
@@ -1,0 +1,37 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: openshift-apiserver-operator-alerts
+  namespace: openshift-apiserver-operator
+  annotations:
+    include.release.openshift.io/hypershift: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+spec:
+  groups:
+  - name: openshift-apiserver-operator.rules
+    rules:
+    - alert: ImageStreamImportFailed
+      expr: |
+        (openshift_imagestreamcontroller_error_count > 0
+        or
+        increase(openshift_imagestreamcontroller_error_count[10m]) > 0)
+      for: 0m
+      labels:
+        severity: warning
+        component: imagestream-controller
+      annotations:
+        summary: "ImageStream import failure detected"
+        description: |
+          One or more ImageStreams failed to import new image tags in the last 10 minutes.
+          Each failure indicates that the ImageStream controller reported ImportSuccess=False for a registry.
+        message: |
+          ImageStream import failure ({{ $value }} errors in 10m).
+          Investigate failing ImageStreams:
+            List all ImageStreams with import failures
+              (`oc get imagestreams --all-namespaces -o wide | grep -v True`);
+            Check status of a specific ImageStream
+              (`oc get -o json imagestream <name> -n <namespace> | jq .status`).
+          The `.status.tags[].conditions` will show specific import failure reasons.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-openshift-apiserver-operator/ImageStreamImportFailed.md


### PR DESCRIPTION
Adds prometheus alert `ImageStreamImportFailed`, for image stream import failure: using the metric `openshift_imagestreamcontroller_error_count`
<img width="2228" height="541" alt="Screenshot 2025-10-14 at 13 45 05" src="https://github.com/user-attachments/assets/1b33ef74-8934-49c0-b368-d455966a9590" />
<img width="1424" height="795" alt="Screenshot 2025-11-25 at 16 01 33" src="https://github.com/user-attachments/assets/261454a6-889e-4c3b-ae1b-12d345ad7838" />

* increase(Counter[Time]) doesn’t count the first value of the counter because increase() always compares with the previous value. For the first time, when the counter has a value of 1, there isn’t any previous value to calculate a difference against. Hence, to account for it, we need to use increase(Counter[Time]) > 0 or Counter > 0