### PR TITLE
CNTRLPLANE-1544: manifests: Use restricted-v3 scc for the operator

### DIFF
--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -23,11 +23,11 @@ spec:
         app: openshift-apiserver-operator
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
-        openshift.io/required-scc: nonroot-v2
+        openshift.io/required-scc: restricted-v3
     spec:
+      hostUsers: false
       securityContext:
         runAsNonRoot: true
-        runAsUser: 65534
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: openshift-apiserver-operator


### PR DESCRIPTION
This effectively enabled user namespaces for the operator.