### PR TITLE
OCPBUGS-23746: Add inertia for APIServicesAvailable condition

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -201,6 +201,10 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 	if infra == nil || infra.Status.ControlPlaneTopology != configv1.SingleReplicaTopologyMode {
 		statusControllerOptions = append(statusControllerOptions, apiservercontrollerset.WithStatusControllerPdbCompatibleHighInertia("APIServer"))
 	}
+	// Add inertia for APIServicesAvailable to prevent brief transient errors
+	statusControllerOptions = append(statusControllerOptions,
+	        apiservercontrollerset.WithStatusControllerAPIServicesAvailableInertia())
+
 
 	apiServerControllers := apiservercontrollerset.NewAPIServerControllerSet(
 		"openshift-apiserver",

--- a/vendor/github.com/openshift/library-go/pkg/operator/apiserver/controllerset/apiservercontrollerset.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/apiserver/controllerset/apiservercontrollerset.go
@@ -170,6 +170,22 @@ func WithStatusControllerPdbCompatibleHighInertia(workloadConditionsPrefix strin
 	}
 }
 
+// WithStatusControllerAPIServicesAvailableInertia sets inertia for APIServicesAvailable
+// conditions to prevent brief transient errors from causing Available=False.
+// This is useful for handling temporary network issues or brief missing HTTP headers
+// that self-resolve within seconds.
+func WithStatusControllerAPIServicesAvailableInertia() func(s *status.StatusSyncer) *status.StatusSyncer {
+	return func(s *status.StatusSyncer) *status.StatusSyncer {
+		return s.WithAvailableInertia(status.MustNewInertia(
+			0, // default: no inertia for other conditions
+			status.InertiaCondition{
+				ConditionTypeMatcher: regexp.MustCompile("^APIServicesAvailable$"),
+				Duration:             5 * time.Second, // tolerate brief transient errors
+			}).Inertia,
+		)
+	}
+}
+
 func (cs *APIServerControllerSet) WithoutClusterOperatorStatusController() *APIServerControllerSet {
 	cs.clusterOperatorStatusController.controller = nil
 	cs.clusterOperatorStatusController.emptyAllowed = true


### PR DESCRIPTION
Add inertia to the APIServicesAvailable condition to prevent brief transient
errors (such as temporary network issues or brief missing HTTP headers) from
causing Available=False. This uses a 5-second tolerance window for these
self-resolving errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>