### PR TITLE
Add test/OWNERS file for proper code ownership

### DIFF
--- a/test/OWNERS
+++ b/test/OWNERS
@@ -2,8 +2,14 @@ reviewers:
   - p0lyn0mial
   - benluddy
   - sanchezl
+  - wangke19
+  - gangwgr
+  - xingxingxia
 approvers:
   - p0lyn0mial
   - benluddy
   - sanchezl
+  - wangke19
+  - gangwgr
+  - xingxingxia
 component: openshift-apiserver


### PR DESCRIPTION
## Summary
This PR adds an OWNERS file for the test directory to ensure proper review and approval processes for test-related changes.

## Details
- Adds `test/OWNERS` with reviewers and approvers
- Update OWNERS which removed names who have left.
- Ensures proper code ownership for test infrastructure changes
- Component: openshift-apiserver

## Reviewers/Approvers
- p0lyn0mial
- benluddy
- sanchezl
- wangke19
- gangwgr
- xingxingxia

This PR is separated from the main OTE migration PR to get consensus on the OWNERS list before proceeding with the infrastructure changes.
