### PR TITLE
share config with check-endpoints

### DIFF
--- a/bindata/v3.11.0/openshift-apiserver/deploy.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/deploy.yaml
@@ -159,6 +159,8 @@ spec:
           - $(POD_NAMESPACE)
           - --v
           - '2'
+          - '--config'
+          - /var/run/configmaps/config/config.yaml
         env:
           - name: POD_NAME
             valueFrom:
@@ -172,6 +174,9 @@ spec:
           - name: check-endpoints
             containerPort: 17698
             protocol: TCP
+        volumeMounts:
+          - name: config
+            mountPath: /var/run/configmaps/config
         resources:
           requests:
             memory: 50Mi

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -317,6 +317,8 @@ spec:
           - $(POD_NAMESPACE)
           - --v
           - '2'
+          - '--config'
+          - /var/run/configmaps/config/config.yaml
         env:
           - name: POD_NAME
             valueFrom:
@@ -330,6 +332,9 @@ spec:
           - name: check-endpoints
             containerPort: 17698
             protocol: TCP
+        volumeMounts:
+          - name: config
+            mountPath: /var/run/configmaps/config
         resources:
           requests:
             memory: 50Mi


### PR DESCRIPTION
Share the config with the check-endpoints container. This ensures that user TLS preferences are respected.