### PR TITLE
MON-4472: Migrate Prometheus targets discovering from Endpoints to EndpointsSlices

### DIFF
--- a/manifests/0000_90_openshift-apiserver-operator_01_prometheusrole.yaml
+++ b/manifests/0000_90_openshift-apiserver-operator_01_prometheusrole.yaml
@@ -20,3 +20,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch

--- a/manifests/0000_90_openshift-apiserver-operator_03_servicemonitor.yaml
+++ b/manifests/0000_90_openshift-apiserver-operator_03_servicemonitor.yaml
@@ -31,3 +31,4 @@ spec:
   selector:
     matchLabels:
       app: openshift-apiserver-operator
+  serviceDiscoveryRole: EndpointSlice

--- a/manifests/0000_90_openshift-apiserver-operator_04_servicemonitor-apiserver.yaml
+++ b/manifests/0000_90_openshift-apiserver-operator_04_servicemonitor-apiserver.yaml
@@ -19,6 +19,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -90,3 +98,4 @@ spec:
   selector:
     matchLabels:
       prometheus: openshift-apiserver
+  serviceDiscoveryRole: EndpointSlice

--- a/manifests/0000_90_openshift-apiserver-operator_05_check-endpoints_servicemonitor.yaml
+++ b/manifests/0000_90_openshift-apiserver-operator_05_check-endpoints_servicemonitor.yaml
@@ -23,3 +23,4 @@ spec:
   selector:
     matchLabels:
       prometheus: openshift-apiserver-check-endpoints
+  serviceDiscoveryRole: EndpointSlice


### PR DESCRIPTION
This PR migrates Prometheus service discovery from the deprecated Endpoints API to the EndpointSlices API, by:

- Setting `serviceDiscoveryRole: EndpointSlice` on ServiceMonitors.
- Granting Prometheus `endpointslices` permissions.

We're taking a conservative approach by keeping the existing `endpoints` permissions alongside the new `endpointslices` ones. This provides a safety net in case any ServiceMonitors, whether deployed from this repo or from another source, still rely on the same Role and were missed during the migration.

That said, since both resources provide essentially the same data, keeping both isn't meaningfully more permissive from a security standpoint.

**These changes target OpenShift 4.22+ and should not be backported to earlier releases.**