### PR TITLE
CNTRLPLANE-2247: Add KMS encryption test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,14 @@ test-e2e-encryption-rotation: GO_TEST_ARGS += -args -provider=$(ENCRYPTION_PROVI
 test-e2e-encryption-rotation: test-unit
 .PHONY: test-e2e-encryption-rotation
 
+# KMS encryption tests
+test-e2e-encryption-kms: GO_TEST_PACKAGES :=./test/e2e-encryption-kms/...
+test-e2e-encryption-kms: GO_TEST_FLAGS += -v
+test-e2e-encryption-kms: GO_TEST_FLAGS += -timeout 4h
+test-e2e-encryption-kms: GO_TEST_FLAGS += -p 1
+test-e2e-encryption-kms: test-unit
+.PHONY: test-e2e-encryption-kms
+
 .PHONY: $(TEST_E2E_ENCRYPTION_ROTATION_TARGETS)
 $(TEST_E2E_ENCRYPTION_ROTATION_TARGETS): test-e2e-encryption-rotation-%:
 	ENCRYPTION_PROVIDER=$* $(MAKE) test-e2e-encryption-rotation

--- a/test/e2e-encryption-kms/encryption_kms_test.go
+++ b/test/e2e-encryption-kms/encryption_kms_test.go
@@ -1,0 +1,20 @@
+package e2e_encryption_kms
+
+import (
+	"testing"
+)
+
+// TestKMSEncryptionOnOff tests KMS encryption on/off cycle.
+// This test:
+// 1. Deploys the mock KMS plugin
+// 2. Enables KMS encryption
+// 3. Verifies secrets are encrypted
+// 4. Disables encryption (Identity)
+// 5. Verifies secrets are not encrypted
+// 6. Re-enables KMS encryption
+// 7. Cleans up
+//
+// TODO: Implement full KMS encryption test once the CI job is validated.
+func TestKMSEncryptionOnOff(t *testing.T) {
+	t.Log("KMS encryption on/off test placeholder - CI job validation")
+}

--- a/test/e2e-encryption-kms/main_test.go
+++ b/test/e2e-encryption-kms/main_test.go
@@ -1,0 +1,31 @@
+package e2e_encryption_kms
+
+import (
+	"math/rand"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+	"unsafe"
+)
+
+func TestMain(m *testing.M) {
+	randomizeTestOrder(m)
+	os.Exit(m.Run())
+}
+
+func randomizeTestOrder(m *testing.M) {
+	pointerVal := reflect.ValueOf(m)
+	val := reflect.Indirect(pointerVal)
+
+	testsMember := val.FieldByName("tests")
+	ptrToTests := unsafe.Pointer(testsMember.UnsafeAddr())
+	realPtrToTests := (*[]testing.InternalTest)(ptrToTests)
+
+	tests := *realPtrToTests
+
+	rand.Seed(time.Now().UnixNano())
+	rand.Shuffle(len(tests), func(i, j int) { tests[i], tests[j] = tests[j], tests[i] })
+
+	*realPtrToTests = tests
+}


### PR DESCRIPTION
This PR adds KMS encryption target to run KMS related e2e tests by bringing the changes in https://github.com/openshift/cluster-kube-apiserver-operator/pull/2014