### PR TITLE
NO-JIRA: OWNERS: remove engineers who have left Red Hat

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,20 +1,12 @@
 reviewers:
   - deads2k
-  - sttts
-  - mfojtik
-  - soltysh
   - p0lyn0mial
-  - tkashem
   - benluddy
   - sanchezl
   - dgrisonnet
 approvers:
   - deads2k
-  - sttts
-  - mfojtik
-  - soltysh
   - p0lyn0mial
-  - tkashem
   - benluddy
   - sanchezl
   - dgrisonnet


### PR DESCRIPTION
## Summary
- Remove engineers who are no longer with Red Hat from OWNERS file

### Removed
- sttts (Stefan Schimanski)
- mfojtik (Michal Fojtik)
- soltysh (Maciej Szulik)
- tkashem (Abu H Kashem)