### PR TITLE
OCPBUGS-72408: add defaults to allowed registries

### DIFF
--- a/bindata/v3.11.0/config/defaultconfig.yaml
+++ b/bindata/v3.11.0/config/defaultconfig.yaml
@@ -30,3 +30,4 @@ imagePolicyConfig:
       - domainName: quay.io
       - domainName: registry.redhat.io
       - domainName: registry.access.redhat.com
+      - domainName: quay-proxy.ci.openshift.org

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -94,6 +94,7 @@ imagePolicyConfig:
       - domainName: quay.io
       - domainName: registry.redhat.io
       - domainName: registry.access.redhat.com
+      - domainName: quay-proxy.ci.openshift.org
 `)
 
 func v3110ConfigDefaultconfigYamlBytes() ([]byte, error) {

--- a/pkg/operator/workload/workload_openshiftapiserver_v311_00_sync_test.go
+++ b/pkg/operator/workload/workload_openshiftapiserver_v311_00_sync_test.go
@@ -405,6 +405,7 @@ func TestCapabilities(t *testing.T) {
 						{DomainName: "quay.io"},
 						{DomainName: "registry.redhat.io"},
 						{DomainName: "registry.access.redhat.com"},
+						{DomainName: "quay-proxy.ci.openshift.org"},
 					},
 				},
 				APIServers: openshiftcontrolplanev1.APIServers{


### PR DESCRIPTION
This PR provides defaults so that the cluster will continue to function even with the change from `allow-all` to `deny-all` introduced here: https://github.com/openshift/openshift-apiserver/pull/607