### PR TITLE
OCPBUGS-72407: add defaults for allowedRegistriesForImport that keep current behavior

### DIFF
--- a/bindata/v3.11.0/config/defaultconfig.yaml
+++ b/bindata/v3.11.0/config/defaultconfig.yaml
@@ -24,3 +24,6 @@ apiServerArguments:
   - "true"
 servingInfo:
   bindNetwork: "tcp"
+imagePolicyConfig:
+  allowedRegistriesForImport:
+    - domainName: "*:*" # allow-all by default to preserve existing behavior

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -88,6 +88,9 @@ apiServerArguments:
   - "true"
 servingInfo:
   bindNetwork: "tcp"
+imagePolicyConfig:
+  allowedRegistriesForImport:
+    - domainName: "*:*" # allow-all by default to preserve existing behavior
 `)
 
 func v3110ConfigDefaultconfigYamlBytes() ([]byte, error) {

--- a/pkg/operator/workload/workload_openshiftapiserver_v311_00_sync_test.go
+++ b/pkg/operator/workload/workload_openshiftapiserver_v311_00_sync_test.go
@@ -395,6 +395,11 @@ func TestCapabilities(t *testing.T) {
 					"shutdown-delay-duration":   {"50s"},
 					"shutdown-send-retry-after": {"true"},
 				},
+				ImagePolicyConfig: openshiftcontrolplanev1.ImagePolicyConfig{
+					AllowedRegistriesForImport: openshiftcontrolplanev1.AllowedRegistries{
+						{DomainName: "*:*"},
+					},
+				},
 				APIServers: openshiftcontrolplanev1.APIServers{
 					PerGroupOptions: tc.expectedPerGroupOptions,
 				},


### PR DESCRIPTION
This PR provides defaults that will keep the current behavior even with the change from allow-all to deny-all introduced here: https://github.com/openshift/openshift-apiserver/pull/608.

This fix and the fix linked above will be backported to all supported releases to resolve OCPBUGS-72407.