### PR TITLE
API-1768:e2e network policy tests

### DIFF
--- a/cmd/cluster-openshift-apiserver-operator-tests-ext/dependencymagnet.go
+++ b/cmd/cluster-openshift-apiserver-operator-tests-ext/dependencymagnet.go
@@ -1,0 +1,10 @@
+// This file imports test packages to ensure they are included in the build.
+// These imports are necessary to register Ginkgo tests with the OpenShift Tests Extension framework.
+package main
+
+import (
+	// Import test packages to register Ginkgo tests
+	// The import below is necessary to ensure that the OAS operator tests are registered with the extension.
+	_ "github.com/openshift/cluster-openshift-apiserver-operator/test/e2e"
+	_ "github.com/openshift/cluster-openshift-apiserver-operator/test/extended"
+)

--- a/cmd/cluster-openshift-apiserver-operator-tests-ext/main.go
+++ b/cmd/cluster-openshift-apiserver-operator-tests-ext/main.go
@@ -18,39 +18,26 @@ import (
 	g "github.com/openshift-eng/openshift-tests-extension/pkg/ginkgo"
 
 	"github.com/spf13/cobra"
-
-	// The import below is necessary to ensure that the OAS operator tests are registered with the extension.
-	_ "github.com/openshift/cluster-openshift-apiserver-operator/test/extended"
 )
 
 func main() {
 	registry := e.NewRegistry()
 	ext := e.NewExtension("openshift", "payload", "cluster-openshift-apiserver-operator")
 
-	// Suite: conformance/parallel (fast, parallel-safe)
+	// Suite: operator/parallel (fast, parallel-safe operator tests)
 	ext.AddSuite(e.Suite{
-		Name:    "openshift/cluster-openshift-apiserver-operator/conformance/parallel",
-		Parents: []string{"openshift/conformance/parallel"},
+		Name: "openshift/cluster-openshift-apiserver-operator/operator/parallel",
 		Qualifiers: []string{
-			`!(name.contains("[Serial]") || name.contains("[Slow]"))`,
+			`name.contains("[Operator]") && !name.contains("[Serial]")`,
 		},
 	})
 
-	// Suite: conformance/serial (explicitly serial tests)
+	// Suite: operator/serial (explicitly serial operator tests)
 	ext.AddSuite(e.Suite{
-		Name:    "openshift/cluster-openshift-apiserver-operator/conformance/serial",
-		Parents: []string{"openshift/conformance/serial"},
+		Name:        "openshift/cluster-openshift-apiserver-operator/operator/serial",
+		Parallelism: 1,
 		Qualifiers: []string{
-			`name.contains("[Serial]")`,
-		},
-	})
-
-	// Suite: optional/slow (long-running tests)
-	ext.AddSuite(e.Suite{
-		Name:    "openshift/cluster-openshift-apiserver-operator/optional/slow",
-		Parents: []string{"openshift/optional/slow"},
-		Qualifiers: []string{
-			`name.contains("[Slow]")`,
+			`name.contains("[Operator]") && name.contains("[Serial]")`,
 		},
 	})
 

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -1,0 +1,815 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"slices"
+	"strings"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	agnhostImage = "registry.k8s.io/e2e-test-images/agnhost:2.45"
+)
+
+// Network Policy helpers
+
+func getNetworkPolicy(ctx context.Context, client kubernetes.Interface, namespace, name string) *networkingv1.NetworkPolicy {
+	g.GinkgoHelper()
+	policy, err := client.NetworkingV1().NetworkPolicies(namespace).Get(ctx, name, metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred(), "failed to get NetworkPolicy %s/%s", namespace, name)
+	return policy
+}
+
+func requireDefaultDenyAll(policy *networkingv1.NetworkPolicy) {
+	g.GinkgoHelper()
+	if len(policy.Spec.PodSelector.MatchLabels) != 0 || len(policy.Spec.PodSelector.MatchExpressions) != 0 {
+		g.Fail(fmt.Sprintf("%s/%s: expected empty podSelector", policy.Namespace, policy.Name))
+	}
+
+	policyTypes := sets.New[string]()
+	for _, policyType := range policy.Spec.PolicyTypes {
+		policyTypes.Insert(string(policyType))
+	}
+	if !policyTypes.Has(string(networkingv1.PolicyTypeIngress)) || !policyTypes.Has(string(networkingv1.PolicyTypeEgress)) {
+		g.Fail(fmt.Sprintf("%s/%s: expected both Ingress and Egress policyTypes, got %v", policy.Namespace, policy.Name, policy.Spec.PolicyTypes))
+	}
+}
+
+func requirePodSelectorLabel(policy *networkingv1.NetworkPolicy, key, value string) {
+	g.GinkgoHelper()
+	actual, ok := policy.Spec.PodSelector.MatchLabels[key]
+	if !ok || actual != value {
+		g.Fail(fmt.Sprintf("%s/%s: expected podSelector %s=%s, got %v", policy.Namespace, policy.Name, key, value, policy.Spec.PodSelector.MatchLabels))
+	}
+}
+
+func requireIngressPort(policy *networkingv1.NetworkPolicy, protocol corev1.Protocol, port int32) {
+	g.GinkgoHelper()
+	if !hasPortInIngress(policy.Spec.Ingress, protocol, port) {
+		g.Fail(fmt.Sprintf("%s/%s: expected ingress port %s/%d", policy.Namespace, policy.Name, protocol, port))
+	}
+}
+
+func requireIngressFromNamespace(policy *networkingv1.NetworkPolicy, port int32, namespace string) {
+	g.GinkgoHelper()
+	if !hasIngressFromNamespace(policy.Spec.Ingress, port, namespace) {
+		g.Fail(fmt.Sprintf("%s/%s: expected ingress from namespace %s on port %d", policy.Namespace, policy.Name, namespace, port))
+	}
+}
+
+func logIngressFromNamespaceOptional(policy *networkingv1.NetworkPolicy, port int32, namespace string) {
+	g.GinkgoHelper()
+	if hasIngressFromNamespace(policy.Spec.Ingress, port, namespace) {
+		g.GinkgoWriter.Printf("networkpolicy %s/%s: ingress from namespace %s present on port %d\n", policy.Namespace, policy.Name, namespace, port)
+		return
+	}
+	g.GinkgoWriter.Printf("networkpolicy %s/%s: no ingress from namespace %s on port %d\n", policy.Namespace, policy.Name, namespace, port)
+}
+
+func requireIngressFromNamespaceOrPolicyGroup(policy *networkingv1.NetworkPolicy, port int32, namespace, policyGroupLabelKey string) {
+	g.GinkgoHelper()
+	if hasIngressFromNamespace(policy.Spec.Ingress, port, namespace) {
+		return
+	}
+	if hasIngressFromPolicyGroup(policy.Spec.Ingress, port, policyGroupLabelKey) {
+		return
+	}
+	g.Fail(fmt.Sprintf("%s/%s: expected ingress from namespace %s or policy-group %s on port %d", policy.Namespace, policy.Name, namespace, policyGroupLabelKey, port))
+}
+
+func requireIngressAllowAll(policy *networkingv1.NetworkPolicy, port int32) {
+	g.GinkgoHelper()
+	if !hasIngressAllowAll(policy.Spec.Ingress, port) {
+		g.Fail(fmt.Sprintf("%s/%s: expected ingress allow-all on port %d", policy.Namespace, policy.Name, port))
+	}
+}
+
+func logIngressHostNetworkOrAllowAll(policy *networkingv1.NetworkPolicy, port int32) {
+	g.GinkgoHelper()
+	if hasIngressAllowAll(policy.Spec.Ingress, port) {
+		g.GinkgoWriter.Printf("networkpolicy %s/%s: ingress allow-all present on port %d\n", policy.Namespace, policy.Name, port)
+		return
+	}
+	if hasIngressFromPolicyGroup(policy.Spec.Ingress, port, "policy-group.network.openshift.io/host-network") {
+		g.GinkgoWriter.Printf("networkpolicy %s/%s: ingress host-network policy-group present on port %d\n", policy.Namespace, policy.Name, port)
+		return
+	}
+	g.GinkgoWriter.Printf("networkpolicy %s/%s: no ingress allow-all/host-network rule on port %d\n", policy.Namespace, policy.Name, port)
+}
+
+func requireEgressPort(policy *networkingv1.NetworkPolicy, protocol corev1.Protocol, port int32) {
+	g.GinkgoHelper()
+	if !hasPortInEgress(policy.Spec.Egress, protocol, port) {
+		g.Fail(fmt.Sprintf("%s/%s: expected egress port %s/%d", policy.Namespace, policy.Name, protocol, port))
+	}
+}
+
+func logEgressAllowAllTCP(policy *networkingv1.NetworkPolicy) {
+	g.GinkgoHelper()
+	if hasEgressAllowAllTCP(policy.Spec.Egress) {
+		g.GinkgoWriter.Printf("networkpolicy %s/%s: egress allow-all TCP rule present\n", policy.Namespace, policy.Name)
+		return
+	}
+	g.GinkgoWriter.Printf("networkpolicy %s/%s: no egress allow-all TCP rule\n", policy.Namespace, policy.Name)
+}
+
+func hasPortInIngress(rules []networkingv1.NetworkPolicyIngressRule, protocol corev1.Protocol, port int32) bool {
+	for _, rule := range rules {
+		if hasPort(rule.Ports, protocol, port) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasPortInEgress(rules []networkingv1.NetworkPolicyEgressRule, protocol corev1.Protocol, port int32) bool {
+	for _, rule := range rules {
+		if hasPort(rule.Ports, protocol, port) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasPort(ports []networkingv1.NetworkPolicyPort, protocol corev1.Protocol, port int32) bool {
+	for _, p := range ports {
+		if p.Port == nil || p.Port.IntValue() != int(port) {
+			continue
+		}
+		pProto := corev1.ProtocolTCP
+		if p.Protocol != nil {
+			pProto = *p.Protocol
+		}
+		if pProto == protocol {
+			return true
+		}
+	}
+	return false
+}
+
+func hasIngressFromNamespace(rules []networkingv1.NetworkPolicyIngressRule, port int32, namespace string) bool {
+	for _, rule := range rules {
+		if !hasPort(rule.Ports, corev1.ProtocolTCP, port) {
+			continue
+		}
+		for _, peer := range rule.From {
+			if namespaceSelectorMatches(peer.NamespaceSelector, namespace) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasIngressAllowAll(rules []networkingv1.NetworkPolicyIngressRule, port int32) bool {
+	for _, rule := range rules {
+		if !hasPort(rule.Ports, corev1.ProtocolTCP, port) {
+			continue
+		}
+		if len(rule.From) == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func hasIngressFromPolicyGroup(rules []networkingv1.NetworkPolicyIngressRule, port int32, policyGroupLabelKey string) bool {
+	for _, rule := range rules {
+		if !hasPort(rule.Ports, corev1.ProtocolTCP, port) {
+			continue
+		}
+		for _, peer := range rule.From {
+			if peer.NamespaceSelector == nil || peer.NamespaceSelector.MatchLabels == nil {
+				continue
+			}
+			if _, ok := peer.NamespaceSelector.MatchLabels[policyGroupLabelKey]; ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasEgressAllowAllTCP(rules []networkingv1.NetworkPolicyEgressRule) bool {
+	for _, rule := range rules {
+		if len(rule.To) != 0 {
+			continue
+		}
+		if hasAnyTCPPort(rule.Ports) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasAnyTCPPort(ports []networkingv1.NetworkPolicyPort) bool {
+	if len(ports) == 0 {
+		return true
+	}
+	for _, p := range ports {
+		if p.Protocol != nil && *p.Protocol != corev1.ProtocolTCP {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func namespaceSelectorMatches(selector *metav1.LabelSelector, namespace string) bool {
+	if selector == nil {
+		return false
+	}
+	if selector.MatchLabels != nil {
+		if selector.MatchLabels["kubernetes.io/metadata.name"] == namespace {
+			return true
+		}
+	}
+	for _, expr := range selector.MatchExpressions {
+		if expr.Key != "kubernetes.io/metadata.name" {
+			continue
+		}
+		if expr.Operator != metav1.LabelSelectorOpIn {
+			continue
+		}
+		for _, value := range expr.Values {
+			if value == namespace {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func restoreNetworkPolicy(ctx context.Context, client kubernetes.Interface, expected *networkingv1.NetworkPolicy) {
+	g.GinkgoHelper()
+	namespace := expected.Namespace
+	name := expected.Name
+	g.GinkgoWriter.Printf("deleting NetworkPolicy %s/%s\n", namespace, name)
+	o.Expect(client.NetworkingV1().NetworkPolicies(namespace).Delete(ctx, name, metav1.DeleteOptions{})).NotTo(o.HaveOccurred())
+	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 10*time.Minute, true, func(ctx context.Context) (bool, error) {
+		current, err := client.NetworkingV1().NetworkPolicies(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		return equality.Semantic.DeepEqual(expected.Spec, current.Spec), nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred(), "timed out waiting for NetworkPolicy %s/%s spec to be restored", namespace, name)
+	g.GinkgoWriter.Printf("NetworkPolicy %s/%s spec restored after delete\n", namespace, name)
+}
+
+func mutateAndRestoreNetworkPolicy(ctx context.Context, client kubernetes.Interface, namespace, name string) {
+	g.GinkgoHelper()
+	original := getNetworkPolicy(ctx, client, namespace, name)
+	g.GinkgoWriter.Printf("mutating NetworkPolicy %s/%s (podSelector override)\n", namespace, name)
+	patch := []byte(`{"spec":{"podSelector":{"matchLabels":{"np-reconcile":"mutated"}}}}`)
+	_, err := client.NetworkingV1().NetworkPolicies(namespace).Patch(ctx, name, types.MergePatchType, patch, metav1.PatchOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 10*time.Minute, true, func(ctx context.Context) (bool, error) {
+		current := getNetworkPolicy(ctx, client, namespace, name)
+		return equality.Semantic.DeepEqual(original.Spec, current.Spec), nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred(), "timed out waiting for NetworkPolicy %s/%s spec to be restored", namespace, name)
+	g.GinkgoWriter.Printf("NetworkPolicy %s/%s spec restored\n", namespace, name)
+}
+
+func waitForPodsReadyByLabel(ctx context.Context, client kubernetes.Interface, namespace, labelSelector string) {
+	g.GinkgoHelper()
+	g.GinkgoWriter.Printf("waiting for pods ready in %s with selector %s\n", namespace, labelSelector)
+	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+		pods, err := client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+		if err != nil {
+			return false, err
+		}
+		if len(pods.Items) == 0 {
+			return false, nil
+		}
+		for _, pod := range pods.Items {
+			if !isPodReady(&pod) {
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred(), "timed out waiting for pods in %s with selector %s to be ready", namespace, labelSelector)
+}
+
+func isPodReady(pod *corev1.Pod) bool {
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+func logNetworkPolicyEvents(ctx context.Context, client kubernetes.Interface, namespaces []string, policyName string) {
+	g.GinkgoHelper()
+	found := false
+	_ = wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+		for _, namespace := range namespaces {
+			events, err := client.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{})
+			if err != nil {
+				g.GinkgoWriter.Printf("unable to list events in %s: %v\n", namespace, err)
+				continue
+			}
+			for _, event := range events.Items {
+				if event.InvolvedObject.Kind == "NetworkPolicy" && event.InvolvedObject.Name == policyName {
+					g.GinkgoWriter.Printf("event in %s: %s %s %s\n", namespace, event.Type, event.Reason, event.Message)
+					found = true
+				}
+			}
+		}
+		if found {
+			return true, nil
+		}
+		g.GinkgoWriter.Printf("no NetworkPolicy events yet for %s (namespaces: %v)\n", policyName, namespaces)
+		return false, nil
+	})
+	if !found {
+		g.GinkgoWriter.Printf("no NetworkPolicy events observed for %s (best-effort)\n", policyName)
+	}
+}
+
+func logNetworkPolicySummary(label string, policy *networkingv1.NetworkPolicy) {
+	g.GinkgoWriter.Printf("networkpolicy %s namespace=%s name=%s podSelector=%v policyTypes=%v ingress=%d egress=%d\n",
+		label,
+		policy.Namespace,
+		policy.Name,
+		policy.Spec.PodSelector.MatchLabels,
+		policy.Spec.PolicyTypes,
+		len(policy.Spec.Ingress),
+		len(policy.Spec.Egress),
+	)
+}
+
+func logNetworkPolicyDetails(label string, policy *networkingv1.NetworkPolicy) {
+	g.GinkgoHelper()
+	g.GinkgoWriter.Printf("networkpolicy %s details:\n", label)
+	g.GinkgoWriter.Printf("  podSelector=%v policyTypes=%v\n", policy.Spec.PodSelector.MatchLabels, policy.Spec.PolicyTypes)
+	for i, rule := range policy.Spec.Ingress {
+		g.GinkgoWriter.Printf("  ingress[%d]: ports=%s from=%s\n", i, formatPorts(rule.Ports), formatPeers(rule.From))
+	}
+	for i, rule := range policy.Spec.Egress {
+		g.GinkgoWriter.Printf("  egress[%d]: ports=%s to=%s\n", i, formatPorts(rule.Ports), formatPeers(rule.To))
+	}
+}
+
+func formatPorts(ports []networkingv1.NetworkPolicyPort) string {
+	if len(ports) == 0 {
+		return "[]"
+	}
+	out := make([]string, 0, len(ports))
+	for _, p := range ports {
+		proto := "TCP"
+		if p.Protocol != nil {
+			proto = string(*p.Protocol)
+		}
+		if p.Port == nil {
+			out = append(out, fmt.Sprintf("%s:any", proto))
+			continue
+		}
+		out = append(out, fmt.Sprintf("%s:%s", proto, p.Port.String()))
+	}
+	return fmt.Sprintf("[%s]", strings.Join(out, ", "))
+}
+
+func formatPeers(peers []networkingv1.NetworkPolicyPeer) string {
+	if len(peers) == 0 {
+		return "[]"
+	}
+	out := make([]string, 0, len(peers))
+	for _, peer := range peers {
+		ns := formatSelector(peer.NamespaceSelector)
+		pod := formatSelector(peer.PodSelector)
+		if ns == "" && pod == "" {
+			out = append(out, "{}")
+			continue
+		}
+		out = append(out, fmt.Sprintf("ns=%s pod=%s", ns, pod))
+	}
+	return fmt.Sprintf("[%s]", strings.Join(out, ", "))
+}
+
+func formatSelector(sel *metav1.LabelSelector) string {
+	if sel == nil {
+		return ""
+	}
+	if len(sel.MatchLabels) == 0 && len(sel.MatchExpressions) == 0 {
+		return "{}"
+	}
+	return fmt.Sprintf("labels=%v exprs=%v", sel.MatchLabels, sel.MatchExpressions)
+}
+
+// Pod helpers
+
+func waitForPodReady(ctx context.Context, kubeClient kubernetes.Interface, namespace, name string) error {
+	return wait.PollUntilContextTimeout(ctx, 2*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+		pod, err := kubeClient.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		if pod.Status.Phase != corev1.PodRunning {
+			return false, nil
+		}
+		for _, cond := range pod.Status.Conditions {
+			if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+}
+
+func podIPs(pod *corev1.Pod) []string {
+	var ips []string
+	for _, podIP := range pod.Status.PodIPs {
+		if podIP.IP != "" {
+			ips = append(ips, podIP.IP)
+		}
+	}
+	if len(ips) == 0 && pod.Status.PodIP != "" {
+		ips = append(ips, pod.Status.PodIP)
+	}
+	return ips
+}
+
+func isIPv6(ip string) bool {
+	return net.ParseIP(ip) != nil && strings.Contains(ip, ":")
+}
+
+func formatIPPort(ip string, port int32) string {
+	if isIPv6(ip) {
+		return fmt.Sprintf("[%s]:%d", ip, port)
+	}
+	return fmt.Sprintf("%s:%d", ip, port)
+}
+
+func serviceClusterIPs(svc *corev1.Service) []string {
+	if len(svc.Spec.ClusterIPs) > 0 {
+		return svc.Spec.ClusterIPs
+	}
+	if svc.Spec.ClusterIP != "" {
+		return []string{svc.Spec.ClusterIP}
+	}
+	return nil
+}
+
+// ensureServiceAccount creates a ServiceAccount for network policy tests if it doesn't exist.
+// Returns a cleanup function that deletes the ServiceAccount.
+func ensureServiceAccount(ctx context.Context, client kubernetes.Interface, namespace string) func() {
+	g.GinkgoHelper()
+	saName := "network-policy-test"
+
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      saName,
+			Namespace: namespace,
+		},
+	}
+
+	_, err := client.CoreV1().ServiceAccounts(namespace).Create(ctx, sa, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		o.Expect(err).NotTo(o.HaveOccurred(), "failed to create ServiceAccount %s/%s", namespace, saName)
+	}
+
+	if apierrors.IsAlreadyExists(err) {
+		g.GinkgoWriter.Printf("ServiceAccount %s/%s already exists\n", namespace, saName)
+		return func() {}
+	}
+
+	g.GinkgoWriter.Printf("created ServiceAccount %s/%s\n", namespace, saName)
+	return func() {
+		g.GinkgoWriter.Printf("deleting ServiceAccount %s/%s\n", namespace, saName)
+		_ = client.CoreV1().ServiceAccounts(namespace).Delete(ctx, saName, metav1.DeleteOptions{})
+	}
+}
+
+func netexecPod(name, namespace string, labels map[string]string, port int32) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+			Annotations: map[string]string{
+				"openshift.io/required-scc": "restricted-v2",
+			},
+		},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: "network-policy-test",
+			SecurityContext: &corev1.PodSecurityContext{
+				SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:  "netexec",
+					Image: agnhostImage,
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: boolptr(false),
+						Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+					},
+					Command: []string{"/agnhost"},
+					Args:    []string{"netexec", fmt.Sprintf("--http-port=%d", port)},
+					Ports: []corev1.ContainerPort{
+						{ContainerPort: port},
+					},
+				},
+			},
+		},
+	}
+}
+
+func createServerPod(ctx context.Context, kubeClient kubernetes.Interface, namespace, name string, labels map[string]string, port int32) ([]string, func()) {
+	g.GinkgoHelper()
+
+	cleanupSA := ensureServiceAccount(ctx, kubeClient, namespace)
+
+	g.GinkgoWriter.Printf("creating server pod %s/%s port=%d labels=%v\n", namespace, name, port, labels)
+	pod := netexecPod(name, namespace, labels, port)
+	_, err := kubeClient.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	o.Expect(waitForPodReady(ctx, kubeClient, namespace, name)).NotTo(o.HaveOccurred())
+
+	created, err := kubeClient.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	o.Expect(created.Status.PodIPs).NotTo(o.BeEmpty())
+
+	ips := podIPs(created)
+	g.GinkgoWriter.Printf("server pod %s/%s ips=%v\n", namespace, name, ips)
+
+	return ips, func() {
+		g.GinkgoWriter.Printf("deleting server pod %s/%s\n", namespace, name)
+		_ = kubeClient.CoreV1().Pods(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+		cleanupSA()
+	}
+}
+
+// Connectivity testing helpers
+
+func expectConnectivityForIP(ctx context.Context, kubeClient kubernetes.Interface, namespace string, clientLabels map[string]string, serverIP string, port int32, shouldSucceed bool) {
+	g.GinkgoHelper()
+
+	podName, cleanup, err := createConnectivityClientPod(ctx, kubeClient, namespace, clientLabels, serverIP, port)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	g.DeferCleanup(cleanup)
+
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+		succeeded, err := readConnectivityResult(ctx, kubeClient, namespace, podName)
+		if err != nil {
+			g.GinkgoWriter.Printf("waiting for connectivity result: %v\n", err)
+			return false, nil
+		}
+		return succeeded == shouldSucceed, nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	g.GinkgoWriter.Printf("connectivity %s/%s expected=%t\n", namespace, formatIPPort(serverIP, port), shouldSucceed)
+}
+
+func expectConnectivity(ctx context.Context, kubeClient kubernetes.Interface, namespace string, clientLabels map[string]string, serverIPs []string, port int32, shouldSucceed bool) {
+	g.GinkgoHelper()
+
+	for _, ip := range serverIPs {
+		family := "IPv4"
+		if isIPv6(ip) {
+			family = "IPv6"
+		}
+		g.GinkgoWriter.Printf("checking %s connectivity %s -> %s expected=%t\n", family, namespace, formatIPPort(ip, port), shouldSucceed)
+		expectConnectivityForIP(ctx, kubeClient, namespace, clientLabels, ip, port, shouldSucceed)
+	}
+}
+
+// createConnectivityClientPod creates a long-running pod that continuously probes
+// TCP connectivity and writes results to stdout. Callers read the pod's logs
+// to determine the latest result, avoiding per-poll pod create/delete overhead.
+func createConnectivityClientPod(ctx context.Context, kubeClient kubernetes.Interface, namespace string, labels map[string]string, serverIP string, port int32) (string, func(), error) {
+	name := fmt.Sprintf("np-client-%s", rand.String(5))
+	target := formatIPPort(serverIP, port)
+
+	cleanupSA := ensureServiceAccount(ctx, kubeClient, namespace)
+
+	g.GinkgoWriter.Printf("creating client pod %s/%s to probe %s\n", namespace, name, target)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+			Annotations: map[string]string{
+				"openshift.io/required-scc": "restricted-v2",
+			},
+		},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: "network-policy-test",
+			RestartPolicy:      corev1.RestartPolicyNever,
+			SecurityContext: &corev1.PodSecurityContext{
+				SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:  "connect",
+					Image: agnhostImage,
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: boolptr(false),
+						Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+					},
+					Command: []string{"/bin/sh", "-c"},
+					Args: []string{
+						fmt.Sprintf("while true; do if /agnhost connect --protocol=tcp --timeout=5s %s 2>/dev/null; then echo CONN_OK; else echo CONN_FAIL; fi; sleep 3; done", target),
+					},
+				},
+			},
+		},
+	}
+
+	_, err := kubeClient.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
+	if err != nil {
+		cleanupSA()
+		return "", nil, err
+	}
+
+	if err := waitForPodReady(ctx, kubeClient, namespace, name); err != nil {
+		_ = kubeClient.CoreV1().Pods(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+		cleanupSA()
+		return "", nil, fmt.Errorf("client pod %s/%s never became ready: %w", namespace, name, err)
+	}
+
+	cleanup := func() {
+		g.GinkgoWriter.Printf("deleting client pod %s/%s\n", namespace, name)
+		_ = kubeClient.CoreV1().Pods(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+		cleanupSA()
+	}
+
+	return name, cleanup, nil
+}
+
+func readConnectivityResult(ctx context.Context, kubeClient kubernetes.Interface, namespace, podName string) (bool, error) {
+	tailLines := int64(1)
+	raw, err := kubeClient.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{
+		TailLines: &tailLines,
+	}).DoRaw(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	line := strings.TrimSpace(string(raw))
+	if line == "" {
+		return false, fmt.Errorf("no connectivity result yet from pod %s/%s", namespace, podName)
+	}
+
+	g.GinkgoWriter.Printf("client pod %s/%s result=%s\n", namespace, podName, line)
+	return line == "CONN_OK", nil
+}
+
+// Policy creation helpers
+
+func defaultDenyPolicy(name, namespace string) *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
+		},
+	}
+}
+
+func allowIngressPolicy(name, namespace string, podLabels, fromLabels map[string]string, port int32) *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{MatchLabels: podLabels},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{
+				{
+					From: []networkingv1.NetworkPolicyPeer{
+						{PodSelector: &metav1.LabelSelector{MatchLabels: fromLabels}},
+					},
+					Ports: []networkingv1.NetworkPolicyPort{
+						{Port: &intstr.IntOrString{Type: intstr.Int, IntVal: port}, Protocol: protocolPtr(corev1.ProtocolTCP)},
+					},
+				},
+			},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		},
+	}
+}
+
+func allowEgressPolicy(name, namespace string, podLabels, toLabels map[string]string, port int32) *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{MatchLabels: podLabels},
+			Egress: []networkingv1.NetworkPolicyEgressRule{
+				{
+					To: []networkingv1.NetworkPolicyPeer{
+						{PodSelector: &metav1.LabelSelector{MatchLabels: toLabels}},
+					},
+					Ports: []networkingv1.NetworkPolicyPort{
+						{Port: &intstr.IntOrString{Type: intstr.Int, IntVal: port}, Protocol: protocolPtr(corev1.ProtocolTCP)},
+					},
+				},
+			},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
+		},
+	}
+}
+
+func ingressAllowsFromNamespace(policy *networkingv1.NetworkPolicy, namespace string, labels map[string]string, port int32) bool {
+	for _, rule := range policy.Spec.Ingress {
+		if !ruleAllowsPort(rule.Ports, port) {
+			continue
+		}
+		if len(rule.From) == 0 {
+			return true
+		}
+		for _, peer := range rule.From {
+			if peer.NamespaceSelector != nil {
+				if nsMatch(peer.NamespaceSelector, namespace) && podMatch(peer.PodSelector, labels) {
+					return true
+				}
+				continue
+			}
+			if podMatch(peer.PodSelector, labels) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func nsMatch(selector *metav1.LabelSelector, namespace string) bool {
+	if selector == nil {
+		return true
+	}
+	if selector.MatchLabels != nil {
+		if selector.MatchLabels["kubernetes.io/metadata.name"] == namespace {
+			return true
+		}
+	}
+	for _, expr := range selector.MatchExpressions {
+		if expr.Key != "kubernetes.io/metadata.name" {
+			continue
+		}
+		if expr.Operator != metav1.LabelSelectorOpIn {
+			continue
+		}
+		if slices.Contains(expr.Values, namespace) {
+			return true
+		}
+	}
+	return false
+}
+
+func podMatch(selector *metav1.LabelSelector, labels map[string]string) bool {
+	if selector == nil {
+		return true
+	}
+	for key, value := range selector.MatchLabels {
+		if labels[key] != value {
+			return false
+		}
+	}
+	return true
+}
+
+func ruleAllowsPort(ports []networkingv1.NetworkPolicyPort, port int32) bool {
+	if len(ports) == 0 {
+		return true
+	}
+	for _, p := range ports {
+		if p.Port == nil {
+			return true
+		}
+		if p.Port.Type == intstr.Int && p.Port.IntVal == port {
+			return true
+		}
+	}
+	return false
+}
+
+// Pointer helpers
+
+func protocolPtr(protocol corev1.Protocol) *corev1.Protocol {
+	return &protocol
+}
+
+func boolptr(value bool) *bool {
+	return &value
+}

--- a/test/e2e/network_policy.go
+++ b/test/e2e/network_policy.go
@@ -1,0 +1,119 @@
+package e2e
+
+import (
+	"context"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+
+	configclient "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	"github.com/openshift/cluster-openshift-apiserver-operator/pkg/operator/operatorclient"
+	test "github.com/openshift/cluster-openshift-apiserver-operator/test/library"
+)
+
+const (
+	apiserverNamespace         = operatorclient.TargetNamespace   // "openshift-apiserver"
+	apiserverOperatorNamespace = operatorclient.OperatorNamespace // "openshift-apiserver-operator"
+	defaultDenyPolicyName      = "default-deny"
+	operatorAllowPolicyName    = "allow-operator"
+	operandAllowPolicyName     = "allow-apiserver"
+)
+
+var _ = g.Describe("[sig-api-machinery] openshift-apiserver operator", func() {
+	g.It("[Operator][NetworkPolicy] should ensure apiserver NetworkPolicies are defined [Suite:openshift/cluster-openshift-apiserver-operator/operator/parallel]", func() {
+		testAPIServerNetworkPolicies()
+	})
+	g.It("[Serial][Operator][NetworkPolicy] should restore apiserver NetworkPolicies after delete or mutation[Timeout:30m] [Suite:openshift/cluster-openshift-apiserver-operator/operator/serial]", func() {
+		testAPIServerNetworkPolicyReconcile()
+	})
+})
+
+func testAPIServerNetworkPolicies() {
+	ctx := context.Background()
+	g.By("Creating Kubernetes clients")
+	kubeConfig, err := test.NewClientConfigForTest()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	configClient, err := configclient.NewForConfig(kubeConfig)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By("Waiting for openshift-apiserver ClusterOperator to be stable")
+	err = test.WaitForClusterOperatorAvailableNotProgressingNotDegraded(ctx, configClient, "openshift-apiserver")
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By("Validating NetworkPolicies in openshift-apiserver-operator")
+	operatorDefaultDeny := getNetworkPolicy(ctx, kubeClient, apiserverOperatorNamespace, defaultDenyPolicyName)
+	logNetworkPolicySummary("apiserver-operator/default-deny", operatorDefaultDeny)
+	logNetworkPolicyDetails("apiserver-operator/default-deny", operatorDefaultDeny)
+	requireDefaultDenyAll(operatorDefaultDeny)
+
+	operatorAllowPolicy := getNetworkPolicy(ctx, kubeClient, apiserverOperatorNamespace, operatorAllowPolicyName)
+	logNetworkPolicySummary("apiserver-operator/"+operatorAllowPolicyName, operatorAllowPolicy)
+	logNetworkPolicyDetails("apiserver-operator/"+operatorAllowPolicyName, operatorAllowPolicy)
+	requirePodSelectorLabel(operatorAllowPolicy, "app", "openshift-apiserver-operator")
+	requireIngressPort(operatorAllowPolicy, corev1.ProtocolTCP, 8443)
+	requireIngressAllowAll(operatorAllowPolicy, 8443)
+	logEgressAllowAllTCP(operatorAllowPolicy)
+
+	g.By("Validating NetworkPolicies in openshift-apiserver")
+	operandDefaultDeny := getNetworkPolicy(ctx, kubeClient, apiserverNamespace, defaultDenyPolicyName)
+	logNetworkPolicySummary("apiserver/default-deny", operandDefaultDeny)
+	logNetworkPolicyDetails("apiserver/default-deny", operandDefaultDeny)
+	requireDefaultDenyAll(operandDefaultDeny)
+
+	operandAllowPolicy := getNetworkPolicy(ctx, kubeClient, apiserverNamespace, operandAllowPolicyName)
+	logNetworkPolicySummary("apiserver/"+operandAllowPolicyName, operandAllowPolicy)
+	logNetworkPolicyDetails("apiserver/"+operandAllowPolicyName, operandAllowPolicy)
+	requirePodSelectorLabel(operandAllowPolicy, "apiserver", "true")
+	requireIngressPort(operandAllowPolicy, corev1.ProtocolTCP, 8443)
+	requireIngressAllowAll(operandAllowPolicy, 8443)
+	logEgressAllowAllTCP(operandAllowPolicy)
+
+	g.By("Verifying pods are ready in apiserver namespaces")
+	waitForPodsReadyByLabel(ctx, kubeClient, apiserverNamespace, "apiserver=true")
+	waitForPodsReadyByLabel(ctx, kubeClient, apiserverOperatorNamespace, "app=openshift-apiserver-operator")
+}
+
+func testAPIServerNetworkPolicyReconcile() {
+	ctx := context.Background()
+	g.By("Creating Kubernetes clients")
+	kubeConfig, err := test.NewClientConfigForTest()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	configClient, err := configclient.NewForConfig(kubeConfig)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By("Waiting for openshift-apiserver ClusterOperator to be stable")
+	err = test.WaitForClusterOperatorAvailableNotProgressingNotDegraded(ctx, configClient, "openshift-apiserver")
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By("Capturing expected NetworkPolicy specs")
+	expectedOperatorPolicy := getNetworkPolicy(ctx, kubeClient, apiserverOperatorNamespace, operatorAllowPolicyName)
+	expectedOperandPolicy := getNetworkPolicy(ctx, kubeClient, apiserverNamespace, operandAllowPolicyName)
+	expectedOperatorDefaultDeny := getNetworkPolicy(ctx, kubeClient, apiserverOperatorNamespace, defaultDenyPolicyName)
+	expectedOperandDefaultDeny := getNetworkPolicy(ctx, kubeClient, apiserverNamespace, defaultDenyPolicyName)
+
+	g.By("Deleting main policies and waiting for restoration")
+	restoreNetworkPolicy(ctx, kubeClient, expectedOperatorPolicy)
+	restoreNetworkPolicy(ctx, kubeClient, expectedOperandPolicy)
+
+	g.By("Deleting default-deny policies and waiting for restoration")
+	restoreNetworkPolicy(ctx, kubeClient, expectedOperatorDefaultDeny)
+	restoreNetworkPolicy(ctx, kubeClient, expectedOperandDefaultDeny)
+
+	g.By("Mutating main policies and waiting for reconciliation")
+	mutateAndRestoreNetworkPolicy(ctx, kubeClient, apiserverOperatorNamespace, operatorAllowPolicyName)
+	mutateAndRestoreNetworkPolicy(ctx, kubeClient, apiserverNamespace, operandAllowPolicyName)
+
+	g.By("Mutating default-deny policies and waiting for reconciliation")
+	mutateAndRestoreNetworkPolicy(ctx, kubeClient, apiserverOperatorNamespace, defaultDenyPolicyName)
+	mutateAndRestoreNetworkPolicy(ctx, kubeClient, apiserverNamespace, defaultDenyPolicyName)
+
+	g.By("Checking NetworkPolicy-related events (best-effort)")
+	logNetworkPolicyEvents(ctx, kubeClient, []string{apiserverOperatorNamespace, apiserverNamespace}, operatorAllowPolicyName)
+}

--- a/test/e2e/network_policy_enforcement.go
+++ b/test/e2e/network_policy_enforcement.go
@@ -1,0 +1,248 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/client-go/kubernetes"
+
+	configclient "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+
+	test "github.com/openshift/cluster-openshift-apiserver-operator/test/library"
+)
+
+var _ = g.Describe("[sig-api-machinery] openshift-apiserver operator", func() {
+	g.It("[Operator][NetworkPolicy] should enforce NetworkPolicy allow/deny basics in a test namespace [Suite:openshift/cluster-openshift-apiserver-operator/operator/parallel]", func() {
+		testGenericNetworkPolicyEnforcement()
+	})
+	g.It("[Operator][NetworkPolicy] should enforce openshift-apiserver NetworkPolicies [Suite:openshift/cluster-openshift-apiserver-operator/operator/parallel]", func() {
+		testAPIServerNetworkPolicyEnforcement()
+	})
+	g.It("[Operator][NetworkPolicy] should enforce openshift-apiserver-operator NetworkPolicies [Suite:openshift/cluster-openshift-apiserver-operator/operator/parallel]", func() {
+		testAPIServerOperatorNetworkPolicyEnforcement()
+	})
+	g.It("[Operator][NetworkPolicy] should enforce cross-namespace ingress traffic [Suite:openshift/cluster-openshift-apiserver-operator/operator/parallel]", func() {
+		testCrossNamespaceIngressEnforcement()
+	})
+	g.It("[Operator][NetworkPolicy] should block unauthorized namespace traffic [Suite:openshift/cluster-openshift-apiserver-operator/operator/parallel]", func() {
+		testUnauthorizedNamespaceBlocking()
+	})
+})
+
+func testGenericNetworkPolicyEnforcement() {
+	ctx := context.Background()
+	kubeConfig, err := test.NewClientConfigForTest()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By("Creating a temporary namespace for policy enforcement checks")
+	nsName := "np-enforcement-" + rand.String(5)
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}}
+	_, err = kubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	g.DeferCleanup(func() {
+		g.GinkgoWriter.Printf("deleting test namespace %s\n", nsName)
+		_ = kubeClient.CoreV1().Namespaces().Delete(ctx, nsName, metav1.DeleteOptions{})
+	})
+
+	serverName := "np-server"
+	clientLabels := map[string]string{"app": "np-client"}
+	serverLabels := map[string]string{"app": "np-server"}
+
+	cleanupSA := ensureServiceAccount(ctx, kubeClient, nsName)
+	g.DeferCleanup(cleanupSA)
+
+	g.GinkgoWriter.Printf("creating netexec server pod %s/%s\n", nsName, serverName)
+	serverPod := netexecPod(serverName, nsName, serverLabels, 8080)
+	_, err = kubeClient.CoreV1().Pods(nsName).Create(ctx, serverPod, metav1.CreateOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	o.Expect(waitForPodReady(ctx, kubeClient, nsName, serverName)).NotTo(o.HaveOccurred())
+
+	server, err := kubeClient.CoreV1().Pods(nsName).Get(ctx, serverName, metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	o.Expect(server.Status.PodIPs).NotTo(o.BeEmpty())
+	serverIPs := podIPs(server)
+	g.GinkgoWriter.Printf("server pod %s/%s ips=%v\n", nsName, serverName, serverIPs)
+
+	g.By("Verifying allow-all when no policies select the pod")
+	expectConnectivity(ctx, kubeClient, nsName, clientLabels, serverIPs, 8080, true)
+
+	g.By("Applying default deny and verifying traffic is blocked")
+	g.GinkgoWriter.Printf("creating default-deny policy in %s\n", nsName)
+	_, err = kubeClient.NetworkingV1().NetworkPolicies(nsName).Create(ctx, defaultDenyPolicy("default-deny", nsName), metav1.CreateOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By("Adding ingress allow only and verifying traffic is still blocked")
+	g.GinkgoWriter.Printf("creating allow-ingress policy in %s\n", nsName)
+	_, err = kubeClient.NetworkingV1().NetworkPolicies(nsName).Create(ctx, allowIngressPolicy("allow-ingress", nsName, serverLabels, clientLabels, 8080), metav1.CreateOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	expectConnectivity(ctx, kubeClient, nsName, clientLabels, serverIPs, 8080, false)
+
+	g.By("Adding egress allow and verifying traffic is permitted")
+	g.GinkgoWriter.Printf("creating allow-egress policy in %s\n", nsName)
+	_, err = kubeClient.NetworkingV1().NetworkPolicies(nsName).Create(ctx, allowEgressPolicy("allow-egress", nsName, clientLabels, serverLabels, 8080), metav1.CreateOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	expectConnectivity(ctx, kubeClient, nsName, clientLabels, serverIPs, 8080, true)
+}
+
+func testAPIServerNetworkPolicyEnforcement() {
+	ctx := context.Background()
+	kubeConfig, err := test.NewClientConfigForTest()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	configClient, err := configclient.NewForConfig(kubeConfig)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	namespace := "openshift-apiserver"
+	serverLabels := map[string]string{"apiserver": "true"}
+
+	g.By("Waiting for openshift-apiserver ClusterOperator to be ready")
+	o.Expect(test.WaitForClusterOperatorAvailableNotProgressingNotDegraded(ctx, configClient, "openshift-apiserver")).NotTo(o.HaveOccurred())
+
+	g.By("Creating openshift-apiserver test pods for allow/deny checks")
+	g.GinkgoWriter.Printf("creating apiserver server pods in %s\n", namespace)
+	allowedServerIPs, cleanupAllowed := createServerPod(ctx, kubeClient, namespace, fmt.Sprintf("np-apiserver-allowed-%s", rand.String(5)), serverLabels, 8443)
+	g.DeferCleanup(cleanupAllowed)
+	deniedServerIPs, cleanupDenied := createServerPod(ctx, kubeClient, namespace, fmt.Sprintf("np-apiserver-denied-%s", rand.String(5)), serverLabels, 12345)
+	g.DeferCleanup(cleanupDenied)
+
+	g.By("Verifying allowed port 8443")
+	expectConnectivity(ctx, kubeClient, "default", map[string]string{"test": "any-client"}, allowedServerIPs, 8443, true)
+
+	g.By("Verifying denied port 12345")
+	expectConnectivity(ctx, kubeClient, "default", map[string]string{"test": "any-client"}, deniedServerIPs, 12345, false)
+
+	g.By("Verifying denied ports even from allowed namespace")
+	for _, port := range []int32{80, 443, 6443, 9090} {
+		expectConnectivity(ctx, kubeClient, "default", map[string]string{"test": "any-client"}, allowedServerIPs, port, false)
+	}
+}
+
+func testAPIServerOperatorNetworkPolicyEnforcement() {
+	ctx := context.Background()
+	kubeConfig, err := test.NewClientConfigForTest()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	configClient, err := configclient.NewForConfig(kubeConfig)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	namespace := "openshift-apiserver-operator"
+	serverLabels := map[string]string{"app": "openshift-apiserver-operator"}
+
+	g.By("Waiting for openshift-apiserver ClusterOperator to be ready")
+	o.Expect(test.WaitForClusterOperatorAvailableNotProgressingNotDegraded(ctx, configClient, "openshift-apiserver")).NotTo(o.HaveOccurred())
+
+	g.By("Creating openshift-apiserver-operator test pods for policy checks")
+	g.GinkgoWriter.Printf("creating apiserver-operator server pod in %s\n", namespace)
+	serverIPs, cleanupServer := createServerPod(ctx, kubeClient, namespace, fmt.Sprintf("np-apiserver-op-server-%s", rand.String(5)), serverLabels, 8443)
+	g.DeferCleanup(cleanupServer)
+
+	g.By("Verifying within-namespace traffic is allowed (metrics port allows all)")
+	expectConnectivity(ctx, kubeClient, namespace, map[string]string{"app": "openshift-apiserver-operator"}, serverIPs, 8443, true)
+
+	g.By("Verifying cross-namespace traffic from monitoring is allowed")
+	expectConnectivity(ctx, kubeClient, "openshift-monitoring", map[string]string{"app.kubernetes.io/name": "prometheus"}, serverIPs, 8443, true)
+
+	g.By("Verifying unauthorized ports are denied")
+	expectConnectivity(ctx, kubeClient, "openshift-monitoring", map[string]string{"app.kubernetes.io/name": "prometheus"}, serverIPs, 12345, false)
+
+	g.By("Verifying metrics port 8443 from openshift-etcd with custom app label: should be denied")
+	expectConnectivity(ctx, kubeClient, "openshift-etcd", map[string]string{"test": "client"}, serverIPs, 8443, false)
+
+	g.By("Verifying metrics port 8443 from openshift-console: should be allowed")
+	expectConnectivity(ctx, kubeClient, "openshift-console", map[string]string{"custom-app": "test-client"}, serverIPs, 8443, true)
+}
+
+func testCrossNamespaceIngressEnforcement() {
+	ctx := context.Background()
+	kubeConfig, err := test.NewClientConfigForTest()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	configClient, err := configclient.NewForConfig(kubeConfig)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By("Waiting for openshift-apiserver ClusterOperator to be ready")
+	o.Expect(test.WaitForClusterOperatorAvailableNotProgressingNotDegraded(ctx, configClient, "openshift-apiserver")).NotTo(o.HaveOccurred())
+
+	g.By("Creating test server pods in apiserver namespaces")
+	apiserverServerIPs, cleanupAPIServer := createServerPod(ctx, kubeClient, "openshift-apiserver", fmt.Sprintf("np-apiserver-xns-%s", rand.String(5)), map[string]string{"apiserver": "true"}, 8443)
+	g.DeferCleanup(cleanupAPIServer)
+	operatorIPs, cleanupOperator := createServerPod(ctx, kubeClient, "openshift-apiserver-operator", fmt.Sprintf("np-apiserver-op-xns-%s", rand.String(5)), map[string]string{"app": "openshift-apiserver-operator"}, 8443)
+	g.DeferCleanup(cleanupOperator)
+
+	g.By("Testing cross-namespace ingress: monitoring -> openshift-apiserver:8443")
+	expectConnectivity(ctx, kubeClient, "openshift-monitoring", map[string]string{"app.kubernetes.io/name": "prometheus"}, apiserverServerIPs, 8443, true)
+
+	g.By("Testing cross-namespace ingress: monitoring -> apiserver-operator:8443")
+	expectConnectivity(ctx, kubeClient, "openshift-monitoring", map[string]string{"app.kubernetes.io/name": "prometheus"}, operatorIPs, 8443, true)
+
+	g.By("Testing allow-all ingress: arbitrary namespace -> openshift-apiserver:8443")
+	expectConnectivity(ctx, kubeClient, "default", map[string]string{"test": "arbitrary-client"}, apiserverServerIPs, 8443, true)
+
+	g.By("Testing denied cross-namespace: unauthorized namespace -> apiserver on unauthorized port")
+	expectConnectivity(ctx, kubeClient, "default", map[string]string{"test": "arbitrary-client"}, apiserverServerIPs, 8080, false)
+
+	g.By("Testing ingress from allowed namespace (labels may vary)")
+	expectConnectivity(ctx, kubeClient, "openshift-monitoring", map[string]string{"app": "wrong-app"}, apiserverServerIPs, 8443, true)
+
+	g.By("Testing cross-namespace: openshift-apiserver -> apiserver-operator allowed (metrics allow-all)")
+	expectConnectivity(ctx, kubeClient, "openshift-apiserver", map[string]string{"apiserver": "true"}, operatorIPs, 8443, true)
+}
+
+func testUnauthorizedNamespaceBlocking() {
+	ctx := context.Background()
+	kubeConfig, err := test.NewClientConfigForTest()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	configClient, err := configclient.NewForConfig(kubeConfig)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By("Waiting for openshift-apiserver ClusterOperator to be ready")
+	o.Expect(test.WaitForClusterOperatorAvailableNotProgressingNotDegraded(ctx, configClient, "openshift-apiserver")).NotTo(o.HaveOccurred())
+
+	g.By("Creating test server pods in apiserver namespaces")
+	apiserverServerIPs, cleanupAPIServer := createServerPod(ctx, kubeClient, "openshift-apiserver", fmt.Sprintf("np-apiserver-unauth-%s", rand.String(5)), map[string]string{"apiserver": "true"}, 8443)
+	g.DeferCleanup(cleanupAPIServer)
+	operatorIPs, cleanupOperator := createServerPod(ctx, kubeClient, "openshift-apiserver-operator", fmt.Sprintf("np-apiserver-op-unauth-%s", rand.String(5)), map[string]string{"app": "openshift-apiserver-operator"}, 8443)
+	g.DeferCleanup(cleanupOperator)
+
+	g.By("Testing allow-all rules: openshift-apiserver:8443 (allow from any namespace)")
+	expectConnectivity(ctx, kubeClient, "default", map[string]string{"test": "any-pod"}, apiserverServerIPs, 8443, true)
+
+	g.By("Testing allow-all metrics: any namespace -> apiserver-operator:8443")
+	expectConnectivity(ctx, kubeClient, "default", map[string]string{"test": "unauthorized"}, operatorIPs, 8443, true)
+
+	g.By("Testing metrics policy: etcd namespace with custom app label should be denied")
+	expectConnectivity(ctx, kubeClient, "openshift-etcd", map[string]string{"test": "unauthorized"}, operatorIPs, 8443, false)
+
+	g.By("Testing metrics policy: console namespace with custom app label can access metrics")
+	expectConnectivity(ctx, kubeClient, "openshift-console", map[string]string{"custom-app": "test-client"}, operatorIPs, 8443, true)
+
+	g.By("Testing port-based blocking: unauthorized port even from any namespace")
+	expectConnectivity(ctx, kubeClient, "default", map[string]string{"test": "any-pod"}, apiserverServerIPs, 9999, false)
+
+	g.By("Testing allow-all metrics: any labels from any namespace")
+	expectConnectivity(ctx, kubeClient, "openshift-monitoring", map[string]string{"app": "wrong-label"}, operatorIPs, 8443, true)
+
+	g.By("Testing multiple unauthorized ports on apiserver")
+	for _, port := range []int32{80, 443, 6443, 22, 3306, 8080} {
+		if port == 8443 {
+			continue
+		}
+		expectConnectivity(ctx, kubeClient, "default", map[string]string{"test": "any-pod"}, apiserverServerIPs, port, false)
+	}
+
+	g.By("Testing cross-namespace blocking: apiserver cannot reach operator on wrong port")
+	expectConnectivity(ctx, kubeClient, "openshift-apiserver", map[string]string{"apiserver": "true"}, operatorIPs, 9999, false)
+}

--- a/test/library/cluster_operator.go
+++ b/test/library/cluster_operator.go
@@ -1,0 +1,37 @@
+package library
+
+import (
+	"context"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	configclient "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+)
+
+// WaitForClusterOperatorAvailableNotProgressingNotDegraded waits for a ClusterOperator to report
+// Available=True, Progressing=False, and Degraded=False status conditions.
+func WaitForClusterOperatorAvailableNotProgressingNotDegraded(ctx context.Context, client configclient.ConfigV1Interface, name string) error {
+	return wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+		co, err := client.ClusterOperators().Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		available := false
+		progressing := true
+		degraded := true
+		for _, condition := range co.Status.Conditions {
+			if condition.Type == "Available" && condition.Status == "True" {
+				available = true
+			}
+			if condition.Type == "Progressing" && condition.Status == "False" {
+				progressing = false
+			}
+			if condition.Type == "Degraded" && condition.Status == "False" {
+				degraded = false
+			}
+		}
+		return available && !progressing && !degraded, nil
+	})
+}


### PR DESCRIPTION
tests for network policy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Registered new e2e test extension and prevented unintended suite inheritance.
  * Added comprehensive NetworkPolicy e2e suites: validation, enforcement, reconciliation, cross-namespace scenarios, and connectivity probes for operator and apiserver components.
  * Added helpers for provisioning test pods, probing connectivity, waiting for readiness, and logging policy events.

* **Chores**
  * Reduced noisy stdout in client config output by routing to verbose logging.
  * Added a robust cluster-operator availability wait utility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->