### PR TITLE
NO-JIRA: Add control-plane-approvers to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,13 +1,7 @@
 reviewers:
-  - deads2k
-  - p0lyn0mial
-  - benluddy
+  - control-plane-approvers
   - sanchezl
-  - dgrisonnet
 approvers:
-  - deads2k
-  - p0lyn0mial
-  - benluddy
+  - control-plane-approvers
   - sanchezl
-  - dgrisonnet
 component: openshift-apiserver

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,16 @@
+aliases:
+  control-plane-approvers:
+    - ardaguclu
+    - atiratree
+    - benluddy
+    - bertinatto
+    - everettraven
+    - flavianmissi
+    - gangwgr
+    - ingvagabund
+    - kaleemsiddiqu
+    - p0lyn0mial
+    - rh-roman
+    - ricardomaraschini
+    - tjungblu
+    - xueqzhan


### PR DESCRIPTION
Add control-plane-approvers to OWNERS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated review and approval configuration: replaced several individual reviewers/approvers with a consolidated approval group and retained existing remaining approver.
  * Added a new alias mapping that defines membership for the consolidated approval group.

This is an administrative update and does not change product functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->