### PR TITLE
CNTRLPLANE-3364: add the kms suite and migrate the kms tests of oas-o to ote

### DIFF
--- a/cmd/cluster-openshift-apiserver-operator-tests-ext/dependencymagnet.go
+++ b/cmd/cluster-openshift-apiserver-operator-tests-ext/dependencymagnet.go
@@ -6,5 +6,6 @@ import (
 	// Import test packages to register Ginkgo tests
 	// The import below is necessary to ensure that the OAS operator tests are registered with the extension.
 	_ "github.com/openshift/cluster-openshift-apiserver-operator/test/e2e"
+	_ "github.com/openshift/cluster-openshift-apiserver-operator/test/e2e-encryption-kms"
 	_ "github.com/openshift/cluster-openshift-apiserver-operator/test/extended"
 )

--- a/cmd/cluster-openshift-apiserver-operator-tests-ext/main.go
+++ b/cmd/cluster-openshift-apiserver-operator-tests-ext/main.go
@@ -46,6 +46,15 @@ func main() {
 		Name: "openshift/cluster-openshift-apiserver-operator/all",
 	})
 
+	// Suite: encryption-kms (KMS encryption tests, serial execution)
+	ext.AddSuite(e.Suite{
+		Name:        "openshift/cluster-openshift-apiserver-operator/encryption-kms",
+		Parallelism: 1,
+		Qualifiers: []string{
+			`name.contains("KMSEncryption")`,
+		},
+	})
+
 	specs, err := g.BuildExtensionTestSpecsFromOpenShiftGinkgoSuite()
 	if err != nil {
 		panic(fmt.Sprintf("couldn't build extension test specs from ginkgo: %+v", err.Error()))

--- a/test/e2e-encryption-kms/encryption_kms.go
+++ b/test/e2e-encryption-kms/encryption_kms.go
@@ -1,0 +1,123 @@
+package e2e_encryption_kms
+
+import (
+	"context"
+	"fmt"
+	"math/rand/v2"
+	"testing"
+
+	g "github.com/onsi/ginkgo/v2"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-openshift-apiserver-operator/pkg/operator/operatorclient"
+	operatorencryption "github.com/openshift/cluster-openshift-apiserver-operator/test/library/encryption"
+	library "github.com/openshift/library-go/test/library/encryption"
+	librarykms "github.com/openshift/library-go/test/library/encryption/kms"
+)
+
+var _ = g.Describe("[sig-openshift-apiserver] cluster-openshift-apiserver-operator", func() {
+	g.It("TestKMSEncryptionOnOff [OCPFeatureGate:KMSEncryption][Serial][Timeout:120m]", func() {
+		testKMSEncryptionOnOff(g.GinkgoTB())
+	})
+
+	g.It("TestKMSEncryptionProvidersMigration [OCPFeatureGate:KMSEncryption][Serial][Timeout:120m]", func() {
+		testKMSEncryptionProvidersMigration(g.GinkgoTB())
+	})
+})
+
+// testKMSEncryptionOnOff tests KMS encryption on/off cycle.
+// This test:
+// 1. Deploys the mock KMS plugin
+// 2. Creates a test OAuth access token (TokenOfLife)
+// 3. Enables KMS encryption
+// 4. Verifies token is encrypted
+// 5. Disables encryption (Identity)
+// 6. Verifies token is NOT encrypted
+// 7. Re-enables KMS encryption
+// 8. Verifies token is encrypted again
+// 9. Disables encryption (Identity) again
+// 10. Verifies token is NOT encrypted again
+func testKMSEncryptionOnOff(t testing.TB) {
+	// Deploy the mock KMS plugin for testing.
+	// NOTE: This manual deployment is only required for KMS v1. In the future,
+	// the platform will manage the KMS plugins, and this code will no longer be needed.
+	librarykms.DeployUpstreamMockKMSPlugin(context.Background(), t, library.GetClients(t).Kube, librarykms.WellKnownUpstreamMockKMSPluginNamespace, librarykms.WellKnownUpstreamMockKMSPluginImage, librarykms.DefaultKMSPluginCount)
+
+	ctx := context.TODO()
+	cs := operatorencryption.GetClients(t)
+
+	ns := fmt.Sprintf("test-kms-encryption-on-off-%d", rand.IntN(4))
+	_, err := cs.KubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+	require.NoError(t, err)
+	defer cs.KubeClient.CoreV1().Namespaces().Delete(ctx, ns, metav1.DeleteOptions{})
+
+	library.TestEncryptionTurnOnAndOff(t, library.OnOffScenario{
+		BasicScenario: library.BasicScenario{
+			Namespace:                       operatorclient.GlobalMachineSpecifiedConfigNamespace,
+			LabelSelector:                   "encryption.apiserver.operator.openshift.io/component" + "=" + operatorclient.TargetNamespace,
+			EncryptionConfigSecretName:      fmt.Sprintf("encryption-config-%s", operatorclient.TargetNamespace),
+			EncryptionConfigSecretNamespace: operatorclient.GlobalMachineSpecifiedConfigNamespace,
+			OperatorNamespace:               operatorclient.OperatorNamespace,
+			TargetGRs:                       operatorencryption.DefaultTargetGRs,
+			AssertFunc:                      operatorencryption.AssertRoutes,
+		},
+		CreateResourceFunc: func(t testing.TB, _ library.ClientSet, namespace string) runtime.Object {
+			return operatorencryption.CreateAndStoreRouteOfLife(context.TODO(), t, operatorencryption.GetClients(t), ns)
+		},
+		AssertResourceEncryptedFunc:    operatorencryption.AssertRouteOfLifeEncrypted,
+		AssertResourceNotEncryptedFunc: operatorencryption.AssertRouteOfLifeNotEncrypted,
+		ResourceFunc:                   func(t testing.TB, _ string) runtime.Object { return operatorencryption.RouteOfLife(t, ns) },
+		ResourceName:                   "TokenOfLife",
+		EncryptionProvider: configv1.APIServerEncryption{
+			Type: configv1.EncryptionTypeKMS,
+			KMS:  librarykms.DefaultFakeKMSPluginConfig,
+		},
+	})
+}
+
+// testKMSEncryptionProvidersMigration tests migration between KMS and AES encryption providers.
+// This test:
+// 1. Deploys the mock KMS plugin
+// 2. Creates a test OAuth access token (TokenOfLife)
+// 3. Randomly picks one AES encryption provider (AESGCM or AESCBC)
+// 4. Shuffles the selected AES provider with KMS to create a randomized migration order
+// 5. Migrates between the providers in the shuffled order
+// 6. Verifies token is correctly encrypted after each migration
+func testKMSEncryptionProvidersMigration(t testing.TB) {
+	librarykms.DeployUpstreamMockKMSPlugin(context.Background(), t, library.GetClients(t).Kube, librarykms.WellKnownUpstreamMockKMSPluginNamespace, librarykms.WellKnownUpstreamMockKMSPluginImage, librarykms.DefaultKMSPluginCount)
+
+	ctx := context.TODO()
+	cs := operatorencryption.GetClients(t)
+
+	ns := fmt.Sprintf("test-kms-encryption-shuffle-%d", rand.IntN(4))
+	_, err := cs.KubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+	require.NoError(t, err)
+	defer cs.KubeClient.CoreV1().Namespaces().Delete(ctx, ns, metav1.DeleteOptions{})
+
+	library.TestEncryptionProvidersMigration(t, library.ProvidersMigrationScenario{
+		BasicScenario: library.BasicScenario{
+			Namespace:                       operatorclient.GlobalMachineSpecifiedConfigNamespace,
+			LabelSelector:                   "encryption.apiserver.operator.openshift.io/component" + "=" + operatorclient.TargetNamespace,
+			EncryptionConfigSecretName:      fmt.Sprintf("encryption-config-%s", operatorclient.TargetNamespace),
+			EncryptionConfigSecretNamespace: operatorclient.GlobalMachineSpecifiedConfigNamespace,
+			OperatorNamespace:               operatorclient.OperatorNamespace,
+			TargetGRs:                       operatorencryption.DefaultTargetGRs,
+			AssertFunc:                      operatorencryption.AssertRoutes,
+		},
+		CreateResourceFunc: func(t testing.TB, _ library.ClientSet, namespace string) runtime.Object {
+			return operatorencryption.CreateAndStoreRouteOfLife(context.TODO(), t, operatorencryption.GetClients(t), ns)
+		},
+		AssertResourceEncryptedFunc:    operatorencryption.AssertRouteOfLifeEncrypted,
+		AssertResourceNotEncryptedFunc: operatorencryption.AssertRouteOfLifeNotEncrypted,
+		ResourceFunc:                   func(t testing.TB, _ string) runtime.Object { return operatorencryption.RouteOfLife(t, ns) },
+		ResourceName:                   "TokenOfLife",
+		EncryptionProviders: library.ShuffleEncryptionProviders([]configv1.APIServerEncryption{
+			{Type: configv1.EncryptionTypeKMS, KMS: librarykms.DefaultFakeKMSPluginConfig},
+			library.SupportedStaticEncryptionProviders[rand.IntN(len(library.SupportedStaticEncryptionProviders))],
+		}),
+	})
+}

--- a/test/e2e-encryption-kms/encryption_kms_test.go
+++ b/test/e2e-encryption-kms/encryption_kms_test.go
@@ -1,112 +1,23 @@
 package e2e_encryption_kms
 
 import (
-	"context"
-	"fmt"
-	"math/rand/v2"
 	"testing"
-
-	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
-	configv1 "github.com/openshift/api/config/v1"
-	"github.com/openshift/cluster-openshift-apiserver-operator/pkg/operator/operatorclient"
-	operatorencryption "github.com/openshift/cluster-openshift-apiserver-operator/test/library/encryption"
-	library "github.com/openshift/library-go/test/library/encryption"
-	librarykms "github.com/openshift/library-go/test/library/encryption/kms"
 )
 
-// TestKMSEncryptionOnOff tests KMS encryption on/off cycle.
-// This test:
-// 1. Deploys the mock KMS plugin
-// 2. Creates a test OAuth access token (TokenOfLife)
-// 3. Enables KMS encryption
-// 4. Verifies token is encrypted
-// 5. Disables encryption (Identity)
-// 6. Verifies token is NOT encrypted
-// 7. Re-enables KMS encryption
-// 8. Verifies token is encrypted again
-// 9. Disables encryption (Identity) again
-// 10. Verifies token is NOT encrypted again
+// This test calls the shared test function which
+// can be called from both standard Go tests and Ginkgo tests.
+//
+// This situation is temporary until we test the new e2e-gcp-operator-encryption-kms-ote job.
+// Eventually all tests will be run only as part of the OTE framework.
 func TestKMSEncryptionOnOff(t *testing.T) {
-	// Deploy the mock KMS plugin for testing.
-	// NOTE: This manual deployment is only required for KMS v1. In the future,
-	// the platform will manage the KMS plugins, and this code will no longer be needed.
-	librarykms.DeployUpstreamMockKMSPlugin(context.Background(), t, library.GetClients(t).Kube, librarykms.WellKnownUpstreamMockKMSPluginNamespace, librarykms.WellKnownUpstreamMockKMSPluginImage, librarykms.DefaultKMSPluginCount)
-
-	ctx := context.TODO()
-	cs := operatorencryption.GetClients(t)
-
-	ns := fmt.Sprintf("test-kms-encryption-on-off-%d", rand.IntN(4))
-	_, err := cs.KubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
-	require.NoError(t, err)
-	defer cs.KubeClient.CoreV1().Namespaces().Delete(ctx, ns, metav1.DeleteOptions{})
-
-	library.TestEncryptionTurnOnAndOff(t, library.OnOffScenario{
-		BasicScenario: library.BasicScenario{
-			Namespace:                       operatorclient.GlobalMachineSpecifiedConfigNamespace,
-			LabelSelector:                   "encryption.apiserver.operator.openshift.io/component" + "=" + operatorclient.TargetNamespace,
-			EncryptionConfigSecretName:      fmt.Sprintf("encryption-config-%s", operatorclient.TargetNamespace),
-			EncryptionConfigSecretNamespace: operatorclient.GlobalMachineSpecifiedConfigNamespace,
-			OperatorNamespace:               operatorclient.OperatorNamespace,
-			TargetGRs:                       operatorencryption.DefaultTargetGRs,
-			AssertFunc:                      operatorencryption.AssertRoutes,
-		},
-		CreateResourceFunc: func(t testing.TB, _ library.ClientSet, namespace string) runtime.Object {
-			return operatorencryption.CreateAndStoreRouteOfLife(context.TODO(), t, operatorencryption.GetClients(t), ns)
-		},
-		AssertResourceEncryptedFunc:    operatorencryption.AssertRouteOfLifeEncrypted,
-		AssertResourceNotEncryptedFunc: operatorencryption.AssertRouteOfLifeNotEncrypted,
-		ResourceFunc:                   func(t testing.TB, _ string) runtime.Object { return operatorencryption.RouteOfLife(t, ns) },
-		ResourceName:                   "TokenOfLife",
-		EncryptionProvider: configv1.APIServerEncryption{
-			Type: configv1.EncryptionTypeKMS,
-			KMS:  librarykms.DefaultFakeKMSPluginConfig,
-		},
-	})
+	testKMSEncryptionOnOff(t)
 }
 
-// TestKMSEncryptionProvidersMigration tests migration between KMS and AES encryption providers.
-// This test:
-// 1. Deploys the mock KMS plugin
-// 2. Creates a test OAuth access token (TokenOfLife)
-// 3. Randomly picks one AES encryption provider (AESGCM or AESCBC)
-// 4. Shuffles the selected AES provider with KMS to create a randomized migration order
-// 5. Migrates between the providers in the shuffled order
-// 6. Verifies token is correctly encrypted after each migration
+// This test calls the shared test function which
+// can be called from both standard Go tests and Ginkgo tests.
+//
+// This situation is temporary until we test the new e2e-gcp-operator-encryption-kms-ote job.
+// Eventually all tests will be run only as part of the OTE framework.
 func TestKMSEncryptionProvidersMigration(t *testing.T) {
-	librarykms.DeployUpstreamMockKMSPlugin(context.Background(), t, library.GetClients(t).Kube, librarykms.WellKnownUpstreamMockKMSPluginNamespace, librarykms.WellKnownUpstreamMockKMSPluginImage, librarykms.DefaultKMSPluginCount)
-
-	ctx := context.TODO()
-	cs := operatorencryption.GetClients(t)
-
-	ns := fmt.Sprintf("test-kms-encryption-shuffle-%d", rand.IntN(4))
-	_, err := cs.KubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
-	require.NoError(t, err)
-	defer cs.KubeClient.CoreV1().Namespaces().Delete(ctx, ns, metav1.DeleteOptions{})
-
-	library.TestEncryptionProvidersMigration(t, library.ProvidersMigrationScenario{
-		BasicScenario: library.BasicScenario{
-			Namespace:                       operatorclient.GlobalMachineSpecifiedConfigNamespace,
-			LabelSelector:                   "encryption.apiserver.operator.openshift.io/component" + "=" + operatorclient.TargetNamespace,
-			EncryptionConfigSecretName:      fmt.Sprintf("encryption-config-%s", operatorclient.TargetNamespace),
-			EncryptionConfigSecretNamespace: operatorclient.GlobalMachineSpecifiedConfigNamespace,
-			OperatorNamespace:               operatorclient.OperatorNamespace,
-			TargetGRs:                       operatorencryption.DefaultTargetGRs,
-			AssertFunc:                      operatorencryption.AssertRoutes,
-		},
-		CreateResourceFunc: func(t testing.TB, _ library.ClientSet, namespace string) runtime.Object {
-			return operatorencryption.CreateAndStoreRouteOfLife(context.TODO(), t, operatorencryption.GetClients(t), ns)
-		},
-		AssertResourceEncryptedFunc:    operatorencryption.AssertRouteOfLifeEncrypted,
-		AssertResourceNotEncryptedFunc: operatorencryption.AssertRouteOfLifeNotEncrypted,
-		ResourceFunc:                   func(t testing.TB, _ string) runtime.Object { return operatorencryption.RouteOfLife(t, ns) },
-		ResourceName:                   "TokenOfLife",
-		EncryptionProviders: library.ShuffleEncryptionProviders([]configv1.APIServerEncryption{
-			{Type: configv1.EncryptionTypeKMS, KMS: librarykms.DefaultFakeKMSPluginConfig},
-			library.SupportedStaticEncryptionProviders[rand.IntN(len(library.SupportedStaticEncryptionProviders))],
-		}),
-	})
+	testKMSEncryptionProvidersMigration(t)
 }


### PR DESCRIPTION
add the kms suite and migrate the kms tests of oas-o to ote

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end KMS encryption tests integrated into the test suite.
  * Validates KMS activation/deactivation cycles and verifies encryption state transitions.
  * Adds provider migration scenarios, exercising switching between KMS and other providers with randomized orders and assertions after each step.
  * Ensures resource lifecycle handling and cleanup for reliable, repeatable execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->