### PR TITLE
NO-jIRA: Remove old mock plugin deployment

### DIFF
--- a/test/e2e-encryption-kms/encryption_kms.go
+++ b/test/e2e-encryption-kms/encryption_kms.go
@@ -41,11 +41,6 @@ var _ = g.Describe("[sig-openshift-apiserver] cluster-openshift-apiserver-operat
 // 9. Disables encryption (Identity) again
 // 10. Verifies token is NOT encrypted again
 func testKMSEncryptionOnOff(ctx context.Context, t testing.TB) {
-	// Deploy the mock KMS plugin for testing.
-	// NOTE: This manual deployment is only required for KMS v1. In the future,
-	// the platform will manage the KMS plugins, and this code will no longer be needed.
-	librarykms.DeployUpstreamMockKMSPlugin(ctx, t, library.GetClients(t).Kube, librarykms.WellKnownUpstreamMockKMSPluginNamespace, librarykms.WellKnownUpstreamMockKMSPluginImage, librarykms.DefaultKMSPluginCount)
-
 	cs := operatorencryption.GetClients(t)
 
 	ns := fmt.Sprintf("test-kms-encryption-on-off-%d", rand.IntN(4))
@@ -83,8 +78,6 @@ func testKMSEncryptionOnOff(ctx context.Context, t testing.TB) {
 // 5. Migrates between the providers in the shuffled order
 // 6. Verifies token is correctly encrypted after each migration
 func testKMSEncryptionProvidersMigration(ctx context.Context, t testing.TB) {
-	librarykms.DeployUpstreamMockKMSPlugin(ctx, t, library.GetClients(t).Kube, librarykms.WellKnownUpstreamMockKMSPluginNamespace, librarykms.WellKnownUpstreamMockKMSPluginImage, librarykms.DefaultKMSPluginCount)
-
 	cs := operatorencryption.GetClients(t)
 
 	ns := fmt.Sprintf("test-kms-encryption-shuffle-%d", rand.IntN(4))


### PR DESCRIPTION
Remove old mock plugin deployment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Simplified KMS encryption end-to-end tests by removing the manual deployment of the upstream mock KMS plugin and streamlining setup; provider selection and existing validation/migration assertions remain unchanged to preserve coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->