### PR TITLE
NO-JIRA: Automatic agentic rebase: Update library-go to 7fd5f33

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/openshift/api v0.0.0-20260521125114-09730f85d883
 	github.com/openshift/build-machinery-go v0.0.0-20251023084048-5d77c1a5e5af
 	github.com/openshift/client-go v0.0.0-20260512113608-deb4dc54551a
-	github.com/openshift/library-go v0.0.0-20260608110537-04693132679d
+	github.com/openshift/library-go v0.0.0-20260611070125-7fd5f333df33
 	github.com/spf13/cobra v1.10.0
 	github.com/stretchr/testify v1.11.1
 	go.etcd.io/etcd/client/v3 v3.6.5

--- a/go.sum
+++ b/go.sum
@@ -174,8 +174,8 @@ github.com/openshift/build-machinery-go v0.0.0-20251023084048-5d77c1a5e5af h1:Ui
 github.com/openshift/build-machinery-go v0.0.0-20251023084048-5d77c1a5e5af/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
 github.com/openshift/client-go v0.0.0-20260512113608-deb4dc54551a h1:EKx2XhOKehd1C5ptY7IrLl4WV35E8kP0pRPnG5BUZXk=
 github.com/openshift/client-go v0.0.0-20260512113608-deb4dc54551a/go.mod h1:V933kvY/cb/Un7UCEOhXHUySNX327u7Epe8g9KNqg2Q=
-github.com/openshift/library-go v0.0.0-20260608110537-04693132679d h1:+n/LOE9kXr8TDLV5ynhx4j3ZuOjeqMc2rKwDKB74W3g=
-github.com/openshift/library-go v0.0.0-20260608110537-04693132679d/go.mod h1:/HBhy6jm/igWI3Y1vYFwFG3ZCcXmnNsKUT6VBpPyM9A=
+github.com/openshift/library-go v0.0.0-20260611070125-7fd5f333df33 h1:k7zdFrfi8699bfWL+ykAn3GF7r2hzIFmMBM8onHrLY0=
+github.com/openshift/library-go v0.0.0-20260611070125-7fd5f333df33/go.mod h1:/HBhy6jm/igWI3Y1vYFwFG3ZCcXmnNsKUT6VBpPyM9A=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20260303184444-1cc650aa0565 h1:3/q8qM4HbFa+Een8wgzpwO8W6mO7Po+MwY6uxiXi/ac=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20260303184444-1cc650aa0565/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/encryptiondata/secret.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/encryptiondata/secret.go
@@ -177,7 +177,7 @@ func ToSecret(ns, name string, secretData *Config) (*corev1.Secret, error) {
 
 	for keyID, flatEntries := range secretData.KMSPluginsConfigMapData.FlatEntriesByKeyID() {
 		for rawKey, value := range flatEntries {
-			s.Data[formatKMSConfigMapDataKey(rawKey, keyID)] = value
+			s.Data[FormatKMSConfigMapDataKey(rawKey, keyID)] = value
 		}
 	}
 
@@ -239,7 +239,7 @@ func FormatKMSSecretDataKey(rawKey, keyID string) string {
 	return fmt.Sprintf("%s%s-%s", encryptionConfigSecretDataPrefix, rawKey, keyID)
 }
 
-// formatKMSConfigMapDataKey returns the data key used in the encryption-config Secret
+// FormatKMSConfigMapDataKey returns the data key used in the encryption-config Secret
 // for a KMS plugin configmap entry: "kms-plugin-configmap-{rawKey}-{keyID}",
 // where rawKey is the combined "configMapName_dataKey" from KMSReferenceData.FlatEntry.
 //
@@ -247,7 +247,7 @@ func FormatKMSSecretDataKey(rawKey, keyID string) string {
 //
 // It does not validate inputs. The callers are expected to use KMSReferenceData.Set,
 // which rejects empty values and underscores in referenceName.
-func formatKMSConfigMapDataKey(rawKey, keyID string) string {
+func FormatKMSConfigMapDataKey(rawKey, keyID string) string {
 	return fmt.Sprintf("%s%s-%s", encryptionConfigConfigMapDataPrefix, rawKey, keyID)
 }
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/vault.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/vault.go
@@ -22,9 +22,17 @@ func newVaultSidecarProvider(name, keyID, udsPath string, vaultConfig configv1.V
 		return nil, err
 	}
 
+	if roleID == "" {
+		return nil, fmt.Errorf("role ID cannot be empty")
+	}
+
 	secretIDPath, err := creds.FilePath(secretName, "secret-id")
 	if err != nil {
 		return nil, err
+	}
+
+	if secretIDPath == "" {
+		return nil, fmt.Errorf("secret ID path cannot be empty")
 	}
 
 	return &vault{
@@ -70,9 +78,15 @@ func (v *vault) BuildSidecarContainer() (corev1.Container, error) {
 		args = append(args, fmt.Sprintf("-vault-namespace=%s", v.config.VaultNamespace))
 	}
 
-	// TODO(bertinatto): this is a temporary workaround until the ca bundle is wired into the
-	// encryption config secret. This should be removed before shipping the KMS feature.
-	args = append(args, "-tls-skip-verify")
+	// Temporary workarounds. These should go away as we progress with the feature.
+	args = append(args,
+		// TODO: remove before GA once the CA bundle is wired into the encryption config secret.
+		"-tls-skip-verify=true",
+		// TODO: remove once we support scraping metrics from each KMS plugin sidecar independently.
+		// Set the port to zero to disable metrics serving.
+		// Slack discussion: https://redhat-external.slack.com/archives/C09KZ5QCBUH/p1780926464635219
+		"-metrics-port=0",
+	)
 
 	return corev1.Container{
 		Name:            v.Name(),

--- a/vendor/github.com/openshift/library-go/test/library/encryption/helpers.go
+++ b/vendor/github.com/openshift/library-go/test/library/encryption/helpers.go
@@ -403,6 +403,34 @@ func WaitForPodImagePullBackOff(ctx context.Context, t testing.TB, kubeClient ku
 	require.NoError(t, err, "timed out waiting for pod to enter ImagePullBackOff in namespace %s", namespace)
 }
 
+// WaitForPodContainerCondition polls pods until at least one pod satisfies the given condition.
+// keyName is the current encryption key secret name, passed to match so callers can
+// correlate pod container names with the active key (e.g. vault-kms-plugin-42).
+func WaitForPodContainerCondition(ctx context.Context, t testing.TB, kubeClient kubernetes.Interface, namespace, labelSelector, keyName string, match func(pod corev1.Pod, keyName string) bool) {
+	t.Helper()
+	t.Logf("Waiting up to %s for a pod in %s (selector=%s, key=%s) to satisfy condition",
+		waitPollTimeout, namespace, labelSelector, keyName)
+	err := wait.PollUntilContextTimeout(ctx, waitPollInterval, waitPollTimeout, true, func(ctx context.Context) (bool, error) {
+		pods, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+		if err != nil {
+			t.Logf("Error listing pods: %v", err)
+			return false, nil
+		}
+		if len(pods.Items) == 0 {
+			t.Logf("No pods found yet in %s", namespace)
+			return false, nil
+		}
+		for _, pod := range pods.Items {
+			if match(pod, keyName) {
+				return true, nil
+			}
+		}
+		t.Logf("No pod yet satisfies condition")
+		return false, nil
+	})
+	require.NoError(t, err, "timed out waiting for a pod in %s to satisfy condition", namespace)
+}
+
 // WaitForCurrentKeyMigrated waits until the current (latest) encryption key has completed
 // migration for all target group resources. It fails if the key changes unexpectedly
 // (i.e. a different key than prevKeyMeta appears).

--- a/vendor/github.com/openshift/library-go/test/library/encryption/kms/vault.go
+++ b/vendor/github.com/openshift/library-go/test/library/encryption/kms/vault.go
@@ -27,6 +27,7 @@ const (
 	defaultVaultPodName            = "vault-0"
 	defaultVaultCredentialsSecret  = "vault-credentials"
 	defaultVaultAppRoleSecretName  = "vault-approle-secret"
+	defaultVaultConfigMapName      = "vault-ca-bundle"
 	defaultFAKEVaultKMSPluginImage = "quay.io/openshifttest/mock-kms-plugin@sha256:958a2f8276037468aa47dc2137d3c30dfcd96489455eddb2fe655f8168a57622"
 	defaultVaultKMSPluginImage     = "registry.ci.openshift.org/control-plane-custom-builds/vault-kube-kms@sha256:33599dd6eee61dcf9a60138759fafda3d88593a3c2072585156882c6b5bd3fa5"
 	defaultVaultAddress            = "https://vault.vault-kms.svc:8200"
@@ -44,16 +45,16 @@ func DefaultVaultEncryptionProvider(ctx context.Context, t testing.TB) library.E
 	cfg := DefaultVaultKMSPluginConfig
 	// Use the Service ClusterIP instead of DNS name because kube-apiserver pods
 	// cannot resolve cluster-local Service names (they use host network DNS).
-	cfg.KMS.Vault.VaultAddress = getVaultServiceAddress(ctx, t)
+	cfg.KMS.Vault.VaultAddress = getVaultServiceAddress(ctx, t, defaultVaultNamespace)
 	return library.EncryptionProvider{
 		APIServerEncryption: cfg,
-		Setup:               ensureDefaultVaultAppRoleSecret,
+		Setup:               ensureVaultAppRoleSecret(defaultVaultNamespace, defaultVaultAppRoleSecretName),
 	}
 }
 
 var DefaultFakeVaultEncryptionProvider = library.EncryptionProvider{
 	APIServerEncryption: DefaultFakeKMSPluginConfig,
-	Setup:               ensureDefaultVaultAppRoleSecret,
+	Setup:               ensureVaultAppRoleSecret(defaultVaultNamespace, defaultVaultAppRoleSecretName),
 }
 
 // DefaultVaultKMSPluginConfig is the standard Vault KMS encryption config
@@ -73,6 +74,12 @@ var DefaultVaultKMSPluginConfig = configv1.APIServerEncryption{
 				AppRole: configv1.VaultAppRoleAuthentication{
 					Secret: configv1.VaultSecretReference{Name: defaultVaultAppRoleSecretName},
 				},
+			},
+			TLS: configv1.VaultTLSConfig{
+				CABundle: configv1.VaultConfigMapReference{
+					Name: defaultVaultConfigMapName,
+				},
+				ServerName: fmt.Sprintf("vault.%s.svc", defaultVaultNamespace),
 			},
 		},
 	},
@@ -98,31 +105,30 @@ var DefaultFakeKMSPluginConfig = configv1.APIServerEncryption{
 	},
 }
 
-// ensureDefaultVaultAppRoleSecret reads credentials from the vault-credentials secret
-// (created by a CI step) and applies the AppRole secret in openshift-config
-// using the default configuration constants.
-func ensureDefaultVaultAppRoleSecret(ctx context.Context, t testing.TB) {
-	t.Helper()
-	cs := library.GetClients(t)
+func ensureVaultAppRoleSecret(vaultNamespace, appRoleSecretName string) func(ctx context.Context, t testing.TB) {
+	return func(ctx context.Context, t testing.TB) {
+		t.Helper()
+		cs := library.GetClients(t)
 
-	creds, err := cs.Kube.CoreV1().Secrets(defaultVaultNamespace).Get(ctx, defaultVaultCredentialsSecret, metav1.GetOptions{})
-	require.NoError(t, err, "failed to read %s/%s secret (was the vault-install CI step run?)", defaultVaultNamespace, defaultVaultCredentialsSecret)
+		creds, err := cs.Kube.CoreV1().Secrets(vaultNamespace).Get(ctx, defaultVaultCredentialsSecret, metav1.GetOptions{})
+		require.NoError(t, err, "failed to read %s/%s secret (was the vault-install CI step run?)", vaultNamespace, defaultVaultCredentialsSecret)
 
-	required := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      defaultVaultAppRoleSecretName,
-			Namespace: defaultAppRoleTargetNamespace,
-		},
-		Type: corev1.SecretTypeOpaque,
-		Data: map[string][]byte{
-			"role-id":   creds.Data["role-id"],
-			"secret-id": creds.Data["secret-id"],
-		},
+		required := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      appRoleSecretName,
+				Namespace: defaultAppRoleTargetNamespace,
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				"role-id":   creds.Data["role-id"],
+				"secret-id": creds.Data["secret-id"],
+			},
+		}
+		recorder := events.NewInMemoryRecorder("vault-approle-secret-setup", clock.RealClock{})
+		_, changed, err := resourceapply.ApplySecret(ctx, cs.Kube.CoreV1(), recorder, required)
+		require.NoError(t, err, "failed to apply AppRole secret")
+		t.Logf("Applied AppRole secret %s in %s (changed=%v)", appRoleSecretName, defaultAppRoleTargetNamespace, changed)
 	}
-	recorder := events.NewInMemoryRecorder("vault-approle-secret-setup", clock.RealClock{})
-	_, changed, err := resourceapply.ApplySecret(ctx, cs.Kube.CoreV1(), recorder, required)
-	require.NoError(t, err, "failed to apply AppRole secret")
-	t.Logf("Applied AppRole secret %s in %s (changed=%v)", defaultVaultAppRoleSecretName, defaultAppRoleTargetNamespace, changed)
 }
 
 func ForceVaultKeyRotation() library.ForceRotationFunc {
@@ -190,12 +196,12 @@ func getCurrentKeyVersion(ctx context.Context, t testing.TB) int {
 
 // getVaultServiceAddress returns the Vault address using the Service's ClusterIP
 // instead of the DNS name, reading the port and scheme from the Service spec.
-func getVaultServiceAddress(ctx context.Context, t testing.TB) string {
+func getVaultServiceAddress(ctx context.Context, t testing.TB, ns string) string {
 	t.Helper()
 	cs := library.GetClients(t)
 
-	svc, err := cs.Kube.CoreV1().Services(defaultVaultNamespace).Get(ctx, "vault", metav1.GetOptions{})
-	require.NoError(t, err, "failed to get vault Service in namespace %s", defaultVaultNamespace)
+	svc, err := cs.Kube.CoreV1().Services(ns).Get(ctx, "vault", metav1.GetOptions{})
+	require.NoError(t, err, "failed to get vault Service in namespace %s", ns)
 	require.NotEmpty(t, svc.Spec.ClusterIP, "vault Service has no ClusterIP")
 	require.NotEmpty(t, svc.Spec.Ports, "vault Service has no ports")
 

--- a/vendor/github.com/openshift/library-go/test/library/encryption/scenarios.go
+++ b/vendor/github.com/openshift/library-go/test/library/encryption/scenarios.go
@@ -353,3 +353,66 @@ func TestKMSInvalidEncryptionRecovery(ctx context.Context, t testing.TB, scenari
 		}
 	}
 }
+
+// KMSInPlaceUpdateScenario tests that updating an in-place KMS config field
+// (e.g. kmsPluginImage) takes effect without creating a new encryption key.
+// The caller supplies Provider (initial valid config) and UpdatedProvider (same config
+// with one in-place field changed).
+type KMSInPlaceUpdateScenario struct {
+	BasicScenario
+	Provider        EncryptionProvider
+	UpdatedProvider EncryptionProvider
+	// WaitForPropagation is called after the in-place update to verify the change
+	// took effect. Receives the current encryption key so callers can match pod
+	// container names to the active key. Same pattern as WaitForStuck in
+	// KMSInvalidEncryptionRecoveryScenario.
+	WaitForPropagation func(ctx context.Context, t testing.TB, keyMeta EncryptionKeyMeta)
+}
+
+// TestKMSInPlaceUpdate validates in-place KMS config field updates:
+//  1. Apply valid provider and verify migration
+//  2. Update in-place field and verify no new encryption key is created
+//  3. WaitForPropagation — caller verifies the change took effect
+func TestKMSInPlaceUpdate(ctx context.Context, t testing.TB, scenario KMSInPlaceUpdateScenario) {
+	e := NewE(t, PrintEventsOnFailure(scenario.OperatorNamespace))
+	clientSet := GetClients(e)
+
+	require.NotNil(t, scenario.Provider.Setup, "Provider.Setup must not be nil")
+	require.NotNil(t, scenario.UpdatedProvider.Setup, "UpdatedProvider.Setup must not be nil")
+	require.NotNil(t, scenario.WaitForPropagation, "WaitForPropagation must not be nil")
+	require.Equal(t, configv1.EncryptionTypeKMS, scenario.Provider.Type, "Provider must use KMS encryption type")
+	require.Equal(t, configv1.EncryptionTypeKMS, scenario.UpdatedProvider.Type, "UpdatedProvider must use KMS encryption type")
+
+	steps := []testStep{
+		{name: "ApplyValidProviderAndVerifyMigration", testFunc: func(t testing.TB) {
+			SetAndWaitForEncryptionType(ctx, t, scenario.Provider, scenario.TargetGRs,
+				scenario.Namespace, scenario.LabelSelector)
+			scenario.AssertFunc(t, clientSet, scenario.Provider.Type,
+				scenario.Namespace, scenario.LabelSelector)
+		}},
+		{name: "UpdateInPlaceField", testFunc: func(t testing.TB) {
+			keyMeta, err := GetLastKeyMeta(t, clientSet.Kube,
+				scenario.Namespace, scenario.LabelSelector)
+			require.NoError(t, err)
+			scenario.UpdatedProvider.Setup(ctx, t)
+			ApplyEncryption(ctx, t, scenario.UpdatedProvider.APIServerEncryption)
+			WaitForNoNewEncryptionKey(t, clientSet.Kube, keyMeta,
+				scenario.Namespace, scenario.LabelSelector)
+		}},
+		{name: "WaitForPropagation", testFunc: func(t testing.TB) {
+			keyMeta, err := GetLastKeyMeta(t, clientSet.Kube,
+				scenario.Namespace, scenario.LabelSelector)
+			require.NoError(t, err)
+			scenario.WaitForPropagation(ctx, t, keyMeta)
+		}},
+	}
+
+	for _, step := range steps {
+		t.Logf("=== STEP: %s ===", step.name)
+		step.testFunc(e)
+		if t.Failed() {
+			t.Errorf("stopping the test as %q step failed", step.name)
+			return
+		}
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -405,7 +405,7 @@ github.com/openshift/client-go/route/applyconfigurations/internal
 github.com/openshift/client-go/route/applyconfigurations/route/v1
 github.com/openshift/client-go/route/clientset/versioned/scheme
 github.com/openshift/client-go/route/clientset/versioned/typed/route/v1
-# github.com/openshift/library-go v0.0.0-20260608110537-04693132679d
+# github.com/openshift/library-go v0.0.0-20260611070125-7fd5f333df33
 ## explicit; go 1.25.0
 github.com/openshift/library-go/pkg/apiserver/jsonpatch
 github.com/openshift/library-go/pkg/apps/deployment


### PR DESCRIPTION
## Summary

Automated dependency update for `github.com/openshift/library-go`.

## Details

- **library-go commit**: [`7fd5f33`](https://github.com/openshift/library-go/commit/7fd5f333df33d1a44e6d6c3601a4052ce011a030)
- **Update date**: 2026-06-11
- **Generated by**: Claude Code agentic workflow

## Changes

- Updated `go.mod` and `go.sum`
- Refreshed vendor directory

## Testing

- [ ] CI tests pass
- [ ] Manual verification recommended

---

🤖 This PR was created automatically by an AI agent using Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to enhance system stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->