### PR TITLE
update networkpolicy for checkendpoints

### DIFF
--- a/bindata/v3.11.0/openshift-apiserver/networkpolicy-allow.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/networkpolicy-allow.yaml
@@ -9,7 +9,8 @@
 #   by cluster configuration.
 #
 # Ingress:
-# - Allow ingress on port 8443 for API requests and metrics scraping.
+# - Allow ingress on port 8443 for API requests and metrics scraping,
+#   and on port 17698 for checkendpoints.
 #   The apiserver performs its own authentication/authorization.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -24,7 +25,6 @@ spec:
   - ports:
     - protocol: TCP
       port: 8443
-  - ports:
     - protocol: TCP
       port: 17698      
   egress:

--- a/bindata/v3.11.0/openshift-apiserver/networkpolicy-allow.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/networkpolicy-allow.yaml
@@ -24,6 +24,9 @@ spec:
   - ports:
     - protocol: TCP
       port: 8443
+  - ports:
+    - protocol: TCP
+      port: 17698      
   egress:
   - {}
   policyTypes:


### PR DESCRIPTION
add port for checkendpoints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated network configuration to allow OpenShift API Server traffic on an additional TCP port, enabling expanded communication routes for the platform infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->