### PR TITLE
NO-JIRA: Add test for KMS to KMS migration

### DIFF
--- a/cmd/cluster-openshift-apiserver-operator-tests-ext/main.go
+++ b/cmd/cluster-openshift-apiserver-operator-tests-ext/main.go
@@ -51,7 +51,17 @@ func main() {
 		Name:        "openshift/cluster-openshift-apiserver-operator/encryption-kms",
 		Parallelism: 1,
 		Qualifiers: []string{
-			`name.contains("KMSEncryption")`,
+			`name.contains("KMSEncryption") && !name.contains("[Suite:encryption-kms-2]")`,
+		},
+	})
+
+	// Suite: encryption-kms-2 (KMS to KMS migration tests, serial execution)
+	ext.AddSuite(e.Suite{
+		Name:        "openshift/cluster-openshift-apiserver-operator/encryption-kms-2",
+		Parents:     []string{"openshift/kms"},
+		Parallelism: 1,
+		Qualifiers: []string{
+			`name.contains("[Suite:encryption-kms-2]")`,
 		},
 	})
 

--- a/test/e2e-encryption-kms/encryption_kms.go
+++ b/test/e2e-encryption-kms/encryption_kms.go
@@ -26,20 +26,20 @@ var _ = g.Describe("[sig-openshift-apiserver] cluster-openshift-apiserver-operat
 	g.It("TestKMSEncryptionProvidersMigration [OCPFeatureGate:KMSEncryption][Serial][Timeout:120m]", func(ctx context.Context) {
 		testKMSEncryptionProvidersMigration(ctx, g.GinkgoTB())
 	})
+
 })
 
 // testKMSEncryptionOnOff tests KMS encryption on/off cycle.
 // This test:
-// 1. Deploys the real Vault KMS plugin
-// 2. Creates a test OAuth access token (TokenOfLife)
-// 3. Enables KMS encryption
-// 4. Verifies token is encrypted
-// 5. Disables encryption (Identity)
-// 6. Verifies token is NOT encrypted
-// 7. Re-enables KMS encryption
-// 8. Verifies token is encrypted again
-// 9. Disables encryption (Identity) again
-// 10. Verifies token is NOT encrypted again
+// 1. Creates a test route (RouteOfLife)
+// 2. Enables KMS encryption
+// 3. Verifies route is encrypted
+// 4. Disables encryption (Identity)
+// 5. Verifies route is NOT encrypted
+// 6. Re-enables KMS encryption
+// 7. Verifies route is encrypted again
+// 8. Disables encryption (Identity) again
+// 9. Verifies route is NOT encrypted again
 func testKMSEncryptionOnOff(ctx context.Context, t testing.TB) {
 	cs := operatorencryption.GetClients(t)
 
@@ -71,12 +71,11 @@ func testKMSEncryptionOnOff(ctx context.Context, t testing.TB) {
 
 // testKMSEncryptionProvidersMigration tests migration between KMS and AES encryption providers.
 // This test:
-// 1. Deploys the real Vault KMS plugin
-// 2. Creates a test OAuth access token (TokenOfLife)
-// 3. Randomly picks one AES encryption provider (AESGCM or AESCBC)
-// 4. Shuffles the selected AES provider with KMS to create a randomized migration order
-// 5. Migrates between the providers in the shuffled order
-// 6. Verifies token is correctly encrypted after each migration
+// 1. Creates a test route (RouteOfLife)
+// 2. Randomly picks one AES encryption provider (AESGCM or AESCBC)
+// 3. Shuffles the selected AES provider with KMS to create a randomized migration order
+// 4. Migrates between the providers in the shuffled order
+// 5. Verifies route is correctly encrypted after each migration
 func testKMSEncryptionProvidersMigration(ctx context.Context, t testing.TB) {
 	cs := operatorencryption.GetClients(t)
 

--- a/test/e2e-encryption-kms/encryption_kms_2.go
+++ b/test/e2e-encryption-kms/encryption_kms_2.go
@@ -1,0 +1,64 @@
+package e2e_encryption_kms
+
+import (
+	"context"
+	"fmt"
+	"math/rand/v2"
+	"testing"
+
+	g "github.com/onsi/ginkgo/v2"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/openshift/cluster-openshift-apiserver-operator/pkg/operator/operatorclient"
+	operatorencryption "github.com/openshift/cluster-openshift-apiserver-operator/test/library/encryption"
+	library "github.com/openshift/library-go/test/library/encryption"
+	librarykms "github.com/openshift/library-go/test/library/encryption/kms"
+)
+
+var _ = g.Describe("[sig-openshift-apiserver] cluster-openshift-apiserver-operator", func() {
+	g.It("TestKMSEncryptionKMSToKMSMigration [OCPFeatureGate:KMSEncryption][Serial][Timeout:120m][Suite:encryption-kms-2]", func(ctx context.Context) {
+		testKMSEncryptionKMSToKMSMigration(ctx, g.GinkgoTB())
+	})
+})
+
+// testKMSEncryptionKMSToKMSMigration tests migration between two distinct KMS providers
+// (default Vault instance and secondary Vault instance).
+// This test:
+// 1. Shuffles the two KMS providers and one AES provider to create a randomized migration order
+// 2. Migrates between the providers in the shuffled order
+// 3. Verifies route is correctly encrypted after each migration
+// 4. Switches to identity (off) to verify the resource is re-written unencrypted
+func testKMSEncryptionKMSToKMSMigration(ctx context.Context, t testing.TB) {
+	cs := operatorencryption.GetClients(t)
+
+	ns := fmt.Sprintf("test-kms-encryption-kms-to-kms-%d", rand.IntN(4))
+	_, err := cs.KubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+	require.NoError(t, err)
+	defer cs.KubeClient.CoreV1().Namespaces().Delete(ctx, ns, metav1.DeleteOptions{})
+
+	library.TestEncryptionProvidersMigration(ctx, t, library.ProvidersMigrationScenario{
+		BasicScenario: library.BasicScenario{
+			Namespace:                       operatorclient.GlobalMachineSpecifiedConfigNamespace,
+			LabelSelector:                   "encryption.apiserver.operator.openshift.io/component" + "=" + operatorclient.TargetNamespace,
+			EncryptionConfigSecretName:      fmt.Sprintf("encryption-config-%s", operatorclient.TargetNamespace),
+			EncryptionConfigSecretNamespace: operatorclient.GlobalMachineSpecifiedConfigNamespace,
+			OperatorNamespace:               operatorclient.OperatorNamespace,
+			TargetGRs:                       operatorencryption.DefaultTargetGRs,
+			AssertFunc:                      operatorencryption.AssertRoutes,
+		},
+		CreateResourceFunc: func(t testing.TB, _ library.ClientSet, namespace string) runtime.Object {
+			return operatorencryption.CreateAndStoreRouteOfLife(context.TODO(), t, operatorencryption.GetClients(t), ns)
+		},
+		AssertResourceEncryptedFunc:    operatorencryption.AssertRouteOfLifeEncrypted,
+		AssertResourceNotEncryptedFunc: operatorencryption.AssertRouteOfLifeNotEncrypted,
+		ResourceFunc:                   func(t testing.TB, _ string) runtime.Object { return operatorencryption.RouteOfLife(t, ns) },
+		ResourceName:                   "RouteOfLife",
+		EncryptionProviders: library.ShuffleEncryptionProviders([]library.EncryptionProvider{
+			librarykms.DefaultVaultEncryptionProvider(ctx, t),
+			librarykms.SecondaryVaultEncryptionProvider(ctx, t),
+		}),
+	})
+}


### PR DESCRIPTION
This PR adds new test for kms to kms migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end coverage for KMS encryption provider migration across multiple Vault-based providers.
  * Added a separate serial test suite for the new migration scenario.
* **Documentation**
  * Updated test descriptions to reflect route encryption behavior more clearly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->