### PR TITLE
OCPBUGS-86583: Allow Prometheus to scrape check-endpoints metrics on port 17698

### DIFF
--- a/bindata/v3.11.0/openshift-apiserver/networkpolicy-allow.yaml
+++ b/bindata/v3.11.0/openshift-apiserver/networkpolicy-allow.yaml
@@ -10,7 +10,8 @@
 #
 # Ingress:
 # - Allow ingress on port 8443 for API requests and metrics scraping.
-#   The apiserver performs its own authentication/authorization.
+# - Allow ingress on port 17698 for check-endpoints metrics scraping.
+#   Both the apiserver and check-endpoints perform their own authentication/authorization.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -24,6 +25,8 @@ spec:
   - ports:
     - protocol: TCP
       port: 8443
+    - protocol: TCP
+      port: 17698
   egress:
   - {}
   policyTypes:

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -475,7 +475,8 @@ var _v3110OpenshiftApiserverNetworkpolicyAllowYaml = []byte(`# Network policy fo
 #
 # Ingress:
 # - Allow ingress on port 8443 for API requests and metrics scraping.
-#   The apiserver performs its own authentication/authorization.
+# - Allow ingress on port 17698 for check-endpoints metrics scraping.
+#   Both the apiserver and check-endpoints perform their own authentication/authorization.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -489,6 +490,8 @@ spec:
   - ports:
     - protocol: TCP
       port: 8443
+    - protocol: TCP
+      port: 17698
   egress:
   - {}
   policyTypes:


### PR DESCRIPTION
## Summary

This PR fixes a NetworkPolicy issue that prevents Prometheus from scraping metrics from the check-endpoints sidecar container, causing `TargetDown` alerts.

## Problem

The `check-endpoints` sidecar container in openshift-apiserver pods exposes metrics on port 17698 for Prometheus scraping. However, the existing `allow-apiserver` NetworkPolicy only allowed ingress on port 8443 (the main API server port), causing Prometheus scrape requests to time out with `context deadline exceeded` errors.

## Solution

Add port 17698 to the existing `allow-apiserver` NetworkPolicy ingress rules. This follows the same pattern as port 8443 - allowing access from anywhere because the check-endpoints container performs its own authentication via:
- Bearer token authentication
- TLS with client certificates

## Changes

1. **NetworkPolicy manifest** (`bindata/v3.11.0/openshift-apiserver/networkpolicy-allow.yaml`):
   - Added port 17698 to the ingress rules alongside port 8443
   - Updated comments to document the new port

2. **Bindata regeneration** (`pkg/operator/v311_00_assets/bindata.go`):
   - Regenerated via `make update` to embed the updated NetworkPolicy

## Testing

- ✅ `make verify` - All verification checks pass
- ✅ `make build` - Builds successfully
- ✅ `make test-unit` - All unit tests pass
- ✅ Manual testing in customer environment confirmed the fix resolves the alerts (see JIRA)

## Related

- **JIRA**: https://redhat.atlassian.net/browse/OCPBUGS-86583
- **Affected Versions**: 4.22.0-rc.3, 4.22.0-rc.4
- **ServiceMonitor**: `manifests/0000_90_openshift-apiserver-operator_05_check-endpoints_servicemonitor.yaml`
- **Service**: `manifests/0000_90_openshift-apiserver-operator_05_check-endpoints_service.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/jira:solve OCPBUGS-86583`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded network access for the OpenShift API server to support additional metrics scraping on a new secure port.
  * Improved compatibility for monitoring by allowing traffic on both the existing API port and the new metrics port.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->