### PR TITLE
NO-JIRA: Retry conflict errors on UpdateKMSEncryptionStatus function

### DIFF
--- a/pkg/operator/encryptionstatusprovider/provider.go
+++ b/pkg/operator/encryptionstatusprovider/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
@@ -43,11 +44,13 @@ func (p *openShiftAPIServerEncryptionStatusProvider) ApplyKMSEncryptionStatus(ct
 }
 
 func (p *openShiftAPIServerEncryptionStatusProvider) UpdateKMSEncryptionStatus(ctx context.Context, mutateFn func(*operatorv1.KMSEncryptionStatus)) error {
-	obj, err := p.client.Get(ctx, "cluster", metav1.GetOptions{})
-	if err != nil {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		obj, err := p.client.Get(ctx, "cluster", metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		mutateFn(&obj.Status.EncryptionStatus)
+		_, err = p.client.UpdateStatus(ctx, obj, metav1.UpdateOptions{})
 		return err
-	}
-	mutateFn(&obj.Status.EncryptionStatus)
-	_, err = p.client.UpdateStatus(ctx, obj, metav1.UpdateOptions{})
-	return err
+	})
 }


### PR DESCRIPTION
Continuation of https://github.com/openshift/cluster-kube-apiserver-operator/pull/2265

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when updating Kubernetes encryption status during concurrent changes.
  * Automatically retries conflicting updates while preserving existing error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->