### PR TITLE
NO-JIRA: observe_images: Prevent spurious ImageStreamImportModeChanged event

### DIFF
--- a/pkg/operator/configobservation/images/observe_images.go
+++ b/pkg/operator/configobservation/images/observe_images.go
@@ -179,7 +179,7 @@ func ObserveImagestreamImportMode(genericListers configobserver.Listers, recorde
 		return prevObservedConfig, append(errs, err)
 	}
 
-	imageStreamImportMode := ""
+	imageStreamImportMode := currentImageStreamImportMode
 	if len(string(configImage.Status.ImageStreamImportMode)) > 0 {
 		imageStreamImportMode = string(configImage.Status.ImageStreamImportMode)
 		err = unstructured.SetNestedField(observedConfig, imageStreamImportMode, imageStreamImportModePath...)

--- a/pkg/operator/configobservation/images/observe_images_test.go
+++ b/pkg/operator/configobservation/images/observe_images_test.go
@@ -216,6 +216,37 @@ func TestObserveImageConfig(t *testing.T) {
 
 }
 
+func TestObserveImagestreamImportModeNoSpuriousEventWhenStatusEmpty(t *testing.T) {
+	// Setup: image config exists but Status.ImageStreamImportMode is not set.
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	if err := indexer.Add(&configv1.Image{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+	}); err != nil {
+		t.Fatalf("failed to add image to indexer: %v", err)
+	}
+	listers := configobservation.Listers{
+		ImageConfigLister: configlistersv1.NewImageLister(indexer),
+	}
+
+	// Simulate a previously observed "Legacy" mode in existingConfig.
+	existingConfig := map[string]any{}
+	if err := unstructured.SetNestedField(existingConfig, string(configv1.ImportModeLegacy), "imagePolicyConfig", "imageStreamImportMode"); err != nil {
+		t.Fatalf("failed to set existingConfig field: %v", err)
+	}
+
+	recorder := events.NewInMemoryRecorder("test", clocktesting.NewFakePassiveClock(time.Now()))
+	_, errs := ObserveImagestreamImportMode(listers, recorder, existingConfig)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+
+	// No "ImageStreamImportModeChanged" event should fire — the status is empty so
+	// nothing actually changed from the previous observation's perspective.
+	if got := recorder.Events(); len(got) != 0 {
+		t.Errorf("expected no events, got %d: %v", len(got), got)
+	}
+}
+
 func TestObserveImageConfigImageStreamImportMode(t *testing.T) {
 	tests := []imageConfigTest{
 		{


### PR DESCRIPTION
When Status.ImageStreamImportMode is unset, initialising the local variable from currentImageStreamImportMode instead of "" avoids a false "changed" comparison that would emit a misleading event and can cause unnecessary reconciliation.

Add a regression test that verifies no event is fired when the existing config holds a mode but the status field is absent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved the existing image stream import mode when no replacement value is provided.
  - Prevented unnecessary configuration updates when the image configuration status is empty, reducing unexpected changes to image behavior.

- **Tests**
  - Added regression coverage to verify that the previous import mode is retained without generating a spurious configuration event.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->