### PR TITLE
OCPBUGS-23746:  operator: suppress brief Available=False blips

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -206,6 +207,9 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 	if infra == nil || infra.Status.ControlPlaneTopology != configv1.SingleReplicaTopologyMode {
 		statusControllerOptions = append(statusControllerOptions, apiservercontrollerset.WithStatusControllerPdbCompatibleHighInertia("APIServer"))
 	}
+	statusControllerOptions = append(statusControllerOptions, func(s *status.StatusSyncer) *status.StatusSyncer {
+		return s.WithAvailableInertia(newAvailableInertia())
+	})
 
 	oasEncryptionStatusProvider, err := encryptionstatusprovider.NewOpenShiftAPIServerEncryptionStatusProvider(operatorConfigClient)
 	if err != nil {
@@ -540,4 +544,24 @@ func extractOperatorStatus(obj *unstructured.Unstructured, fieldManager string) 
 		return nil, nil
 	}
 	return &ret.Status.OperatorStatusApplyConfiguration, nil
+}
+
+func newAvailableInertia() status.Inertia {
+	return status.MustNewInertia(
+		0,
+		// Suppress brief Available=False blips (1–4 s) that occur when the
+		// openshift-apiserver deployment is rolled: endpoint slices momentarily
+		// lose all addresses, or the deployment object is briefly unretrievable
+		// while the CVO patches it.  Zero default so no other Available
+		// sub-condition is affected.
+		inertiaForCondition("APIServicesAvailable", 10*time.Second),
+		inertiaForCondition("APIServerDeploymentAvailable", 10*time.Second),
+	).Inertia
+}
+
+func inertiaForCondition(cond string, duration time.Duration) status.InertiaCondition {
+	return status.InertiaCondition{
+		ConditionTypeMatcher: regexp.MustCompile("^" + cond + "$"),
+		Duration:             duration,
+	}
 }

--- a/pkg/operator/starter_test.go
+++ b/pkg/operator/starter_test.go
@@ -1,0 +1,40 @@
+package operator
+
+import (
+	"testing"
+	"time"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+)
+
+func TestNewAvailableInertia(t *testing.T) {
+	inertia := newAvailableInertia()
+
+	tests := []struct {
+		conditionType string
+		expected      time.Duration
+	}{
+		{
+			conditionType: "APIServicesAvailable",
+			expected:      10 * time.Second,
+		},
+		{
+			conditionType: "APIServerDeploymentAvailable",
+			expected:      10 * time.Second,
+		},
+		{
+			// Any other Available sub-condition must not be affected.
+			conditionType: "SomeOtherAvailable",
+			expected:      0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.conditionType, func(t *testing.T) {
+			got := inertia(operatorv1.OperatorCondition{Type: tt.conditionType})
+			if got != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add a 10-second inertia for the APIServicesAvailable and
APIServerDeploymentAvailable sub-conditions. This prevents transient
1–4 second gaps — caused by endpoint slices momentarily losing all
addresses when the openshift-apiserver deployment is rolled, or by the
deployment object being briefly unretrievable while the CVO patches it —
from propagating to ClusterOperator.Available=False.

The inertia is scoped to exactly these two sub-conditions (zero default)
so no other Available contributor is affected. Genuine outages that
persist beyond 10 s still surface immediately.

More details are available in a doc linked in a comment on the Jira issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved API server availability reporting by preventing brief, transient failures from immediately changing availability status.
  - Availability status now allows a 10-second stabilization period for key API service and deployment conditions.
  - Other availability conditions continue to be reported without this delay.

- **Chores**
  - Updated an underlying OpenShift library dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->